### PR TITLE
Fix cargo build error

### DIFF
--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -84,7 +84,7 @@ unsafe impl ExternType for TweakDBID {
     type Kind = cxx::kind::Trivial;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct REDString {
     data: [i8; 0x14],


### PR DESCRIPTION
error: `Debug` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy`