### PR TITLE
Support for EntityID

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -6,12 +6,17 @@ define_plugin! {
     version: 0:1:0,
     on_register: {
         register_function!("SumInts", sum_ints);
+        register_function!("UseTypes", use_types);
         register_function!("CallDemo", call_demo);
     }
 }
 
 fn sum_ints(ints: Vec<i32>) -> i32 {
     ints.iter().sum()
+}
+
+fn use_types(name: CName, tweak: TweakDbId, item: ItemId, entity: EntityId) {
+    info!("got CName {:#?}, TweakDBID {:#?}, ItemID {:#?}, EntityID {:#?}", name, tweak, item, entity);
 }
 
 fn call_demo(player: PlayerPuppet) {

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -16,7 +16,10 @@ fn sum_ints(ints: Vec<i32>) -> i32 {
 }
 
 fn use_types(name: CName, tweak: TweakDbId, item: ItemId, entity: EntityId) {
-    info!("got CName {:#?}, TweakDBID {:#?}, ItemID {:#?}, EntityID {:#?}", name, tweak, item, entity);
+    info!(
+        "got CName {:#?}, TweakDBID {:#?}, ItemID {:#?}, EntityID {:#?}",
+        name, tweak, item, entity
+    );
 }
 
 fn call_demo(player: PlayerPuppet) {

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -167,7 +167,7 @@ impl From<Seed> for u32 {
 }
 
 /// see [its C++ representation](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/entEntityID.hpp#L7)
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct EntityId {
     hash: u64,
 }
@@ -179,14 +179,9 @@ impl From<u64> for EntityId {
 }
 
 impl EntityId {
-    const DYNAMIC_UPPER_BOUND: u64 = 0xFFFFFF;
-    const PERSISTABLE_LOWER_BOUND: u64 = 9000000;
-    const PERSISTABLE_UPPER_BOUND: u64 = 10000000;
-
-    #[inline]
-    pub fn new() -> Self {
-        0.into()
-    }
+    const DYNAMIC_UPPER_BOUND: u64 = 0x00FF_FFFF;
+    const PERSISTABLE_LOWER_BOUND: u64 = 9_000_000;
+    const PERSISTABLE_UPPER_BOUND: u64 = 10_000_000;
 
     #[inline]
     pub fn is_defined(&self) -> bool {

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -166,6 +166,54 @@ impl From<Seed> for u32 {
     }
 }
 
+/// see [its C++ representation](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/entEntityID.hpp#L7)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityId {
+    hash: u64,
+}
+
+impl From<u64> for EntityId {
+    fn from(hash: u64) -> Self {
+        Self { hash }
+    }
+}
+
+impl EntityId {
+    const DYNAMIC_UPPER_BOUND: u64 = 0xFFFFFF;
+    const PERSISTABLE_LOWER_BOUND: u64 = 9000000;
+    const PERSISTABLE_UPPER_BOUND: u64 = 10000000;
+
+    #[inline]
+    pub fn new() -> Self {
+        0.into()
+    }
+
+    #[inline]
+    pub fn is_defined(&self) -> bool {
+        self.hash != 0
+    }
+
+    #[inline]
+    pub fn is_static(&self) -> bool {
+        self.hash != 0 && self.hash > Self::DYNAMIC_UPPER_BOUND
+    }
+
+    #[inline]
+    pub fn is_dynamic(&self) -> bool {
+        self.hash != 0 && self.hash <= Self::DYNAMIC_UPPER_BOUND
+    }
+
+    #[inline]
+    pub fn is_persistable(&self) -> bool {
+        self.hash >= Self::PERSISTABLE_LOWER_BOUND && self.hash < Self::PERSISTABLE_UPPER_BOUND
+    }
+}
+
+unsafe impl ExternType for EntityId {
+    type Id = type_id!("RED4ext::EntityID");
+    type Kind = cxx::kind::Trivial;
+}
+
 #[derive(Debug, Clone)]
 #[repr(C, packed)]
 pub struct RedString {

--- a/red4ext-sys/src/lib.rs
+++ b/red4ext-sys/src/lib.rs
@@ -38,6 +38,8 @@ pub mod ffi {
         type TweakDbId = crate::interop::TweakDbId;
         #[cxx_name = "ItemID"]
         type ItemId = crate::interop::ItemId;
+        #[cxx_name = "EntityID"]
+        type EntityId = crate::interop::EntityId;
         type CStackType = crate::interop::StackArg;
         type Variant = crate::interop::Variant;
 

--- a/red4ext/src/conv.rs
+++ b/red4ext/src/conv.rs
@@ -1,6 +1,6 @@
 use const_combine::bounded::const_combine;
-use red4ext_sys::interop::{Mem, ItemId};
-use red4ext_sys::{ffi, interop::EntityId};
+use red4ext_sys::ffi;
+use red4ext_sys::interop::{EntityId, ItemId, Mem};
 
 use crate::types::{
     CName, Color, IScriptable, RedArray, RedString, Ref, ScriptRef, TweakDbId, Variant, Vector2,

--- a/red4ext/src/conv.rs
+++ b/red4ext/src/conv.rs
@@ -1,6 +1,6 @@
 use const_combine::bounded::const_combine;
-use red4ext_sys::ffi;
 use red4ext_sys::interop::Mem;
+use red4ext_sys::{ffi, interop::EntityId};
 
 use crate::types::{
     CName, Color, IScriptable, RedArray, RedString, Ref, ScriptRef, TweakDbId, Variant, Vector2,
@@ -145,6 +145,7 @@ impl_native_repr!(u8, "Uint8");
 impl_native_repr!(bool, "Bool");
 impl_native_repr!(CName, "CName");
 impl_native_repr!(TweakDbId, "TweakDBID");
+impl_native_repr!(EntityId, "EntityID");
 impl_native_repr!(Vector2, "Vector2");
 impl_native_repr!(Color, "Color");
 impl_native_repr!(Ref<IScriptable>, "handle:IScriptable");

--- a/red4ext/src/conv.rs
+++ b/red4ext/src/conv.rs
@@ -1,5 +1,5 @@
 use const_combine::bounded::const_combine;
-use red4ext_sys::interop::Mem;
+use red4ext_sys::interop::{Mem, ItemId};
 use red4ext_sys::{ffi, interop::EntityId};
 
 use crate::types::{
@@ -145,6 +145,7 @@ impl_native_repr!(u8, "Uint8");
 impl_native_repr!(bool, "Bool");
 impl_native_repr!(CName, "CName");
 impl_native_repr!(TweakDbId, "TweakDBID");
+impl_native_repr!(ItemId, "ItemID");
 impl_native_repr!(EntityId, "EntityID");
 impl_native_repr!(Vector2, "Vector2");
 impl_native_repr!(Color, "Color");

--- a/red4ext/src/prelude.rs
+++ b/red4ext/src/prelude.rs
@@ -3,8 +3,8 @@ pub use crate::conv::{FromRepr, IntoRepr, NativeRepr};
 pub use crate::macros::{redscript_global, redscript_import};
 pub use crate::plugin::{Plugin, Version};
 pub use crate::types::{
-    CName, GameEItemIdFlag, GamedataItemStructure, IScriptable, ItemId, RedArray, RedString, Ref,
-    ScriptRef, TweakDbId, VariantExt,
+    CName, EntityId, GameEItemIdFlag, GamedataItemStructure, IScriptable, ItemId, RedArray,
+    RedString, Ref, ScriptRef, TweakDbId, VariantExt,
 };
 pub use crate::{
     call, debug, define_plugin, define_trait_plugin, error, info, register_function, trace, warn,

--- a/red4ext/src/types.rs
+++ b/red4ext/src/types.rs
@@ -4,7 +4,8 @@ use std::{mem, pin, ptr};
 pub use ffi::IScriptable;
 use red4ext_sys::ffi;
 pub use red4ext_sys::interop::{
-    CName, GameEItemIdFlag, GamedataItemStructure, ItemId, RedString, TweakDbId, Variant, VoidPtr,
+    CName, EntityId, GameEItemIdFlag, GamedataItemStructure, ItemId, RedString, TweakDbId, Variant,
+    VoidPtr,
 };
 
 use crate::conv::{FromRepr, IntoRepr, NativeRepr};


### PR DESCRIPTION
Add support for EntityID.

Sources links:

- [cyberdoc](https://jac3km4.github.io/cyberdoc/#10085)
- [RED4ext.SDK](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/entEntityID.hpp#L7)
- [CET](https://github.com/maximegmd/CyberEngineTweaks/blob/master/src/reverse/RTTIExtender.cpp#L7)

As far as I understood, its name in C++ is `entEntityID` but it has an alias `EntityID`, so I guess it should be fine ?