### PR TITLE
fix/ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
       - run: cargo build --release
       - uses: actions/upload-artifact@v3
         with:
-          path: target/release/red4ext_example.dll
+          path: target/release/example.dll

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ As a convenience, it already provides most common [literal types](https://wiki.r
 
 - `CName`
 - `TweakDBID`
-- `ResRef` and `RaRef`
+- `ResRef`
 
 and native structs:
 


### PR DESCRIPTION
2 minor fixes:

1. renamed `red4ext-example`'s bin name to `example` (previously in 2a5e768), so updated CI accordingly (see [warning in latest Action run](https://github.com/jac3km4/red4ext-rs/actions/runs/4969926166)).

1. removed mention of `RaRef` in readme since it's not supported.