### PR TITLE
fix: call static method from native struct

### DIFF
--- a/example/reds/Natives.reds
+++ b/example/reds/Natives.reds
@@ -1,3 +1,3 @@
 native func SumInts(ints: array<Int32>) -> Int32;
-native func UseTypes(name: CName, tweak: TweakDBID, item: ItemID, entity: EntityID, res: ResRef) -> Void;
+native func UseTypes(name: CName, tweak: TweakDBID, item: ItemID, entity: EntityID, res: ResRef, sim: EngineTime) -> Void;
 native func CallDemo(player: ref<PlayerPuppet>) -> Void;

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -27,13 +27,18 @@ fn sum_ints(ints: Vec<i32>) -> i32 {
 /// try in-game in CET console:
 ///
 /// ```lua
-/// UseTypes(CName.new("Test"), TDBID.Create("Items.BlackLaceV0"), ItemID.FromTDBID(TDBID.Create("Items.BlackLaceV0")), Game.GetPlayer():GetEntityID(), "base\\characters\\entities\\player\\player_ma_fpp.ent")
+/// UseTypes(CName.new("Test"), TDBID.Create("Items.BlackLaceV0"), ItemID.FromTDBID(TDBID.Create("Items.BlackLaceV0")), Game.GetPlayer():GetEntityID(), "base\\characters\\entities\\player\\player_ma_fpp.ent", Game.GetTimeSystem():GetSimTime())
 /// ```
 /// > ⚠️ output can be found in mod's logs
-fn use_types(name: CName, tweak: TweakDbId, item: ItemId, entity: EntityId, res: ResRef) {
+fn use_types(name: CName, tweak: TweakDbId, item: ItemId, entity: EntityId, res: ResRef, sim: EngineTime) {
     info!("got CName {name:#?}, TweakDBID {tweak:#?}, ItemID {item:#?}, EntityID {entity:#?}, ResRef {res:#?}");
     let res = res_ref!("base" / "mod" / "custom.ent").unwrap();
     info!("created res ref: {res:#?}");
+    info!(
+        "engine time: {:?} = {}",
+        sim,
+        EngineTime::to_float(sim)
+    );
 }
 
 /// call function with handle
@@ -100,4 +105,24 @@ unsafe impl RefRepr for PlayerPuppet {
     type Type = Weak;
 
     const CLASS_NAME: &'static str = "PlayerPuppet";
+}
+
+/// define a binding for a native struct type
+/// 
+/// see [RED4ext.SDK](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/Generated/EngineTime.hpp)
+#[derive(Debug, Default, Clone, Copy)]
+#[repr(C)]
+struct EngineTime {
+    pub unk00: [u8; 8],
+}
+
+unsafe impl NativeRepr for EngineTime {
+    const NAME: &'static str = "EngineTime";
+}
+
+#[redscript_import]
+impl EngineTime {
+    /// imports `public static native func ToFloat(self: EngineTime) -> Float`
+    #[redscript(native)]
+    fn to_float(time: EngineTime) -> f32;
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -30,15 +30,18 @@ fn sum_ints(ints: Vec<i32>) -> i32 {
 /// UseTypes(CName.new("Test"), TDBID.Create("Items.BlackLaceV0"), ItemID.FromTDBID(TDBID.Create("Items.BlackLaceV0")), Game.GetPlayer():GetEntityID(), "base\\characters\\entities\\player\\player_ma_fpp.ent", Game.GetTimeSystem():GetSimTime())
 /// ```
 /// > ⚠️ output can be found in mod's logs
-fn use_types(name: CName, tweak: TweakDbId, item: ItemId, entity: EntityId, res: ResRef, sim: EngineTime) {
+fn use_types(
+    name: CName,
+    tweak: TweakDbId,
+    item: ItemId,
+    entity: EntityId,
+    res: ResRef,
+    sim: EngineTime,
+) {
     info!("got CName {name:#?}, TweakDBID {tweak:#?}, ItemID {item:#?}, EntityID {entity:#?}, ResRef {res:#?}");
     let res = res_ref!("base" / "mod" / "custom.ent").unwrap();
     info!("created res ref: {res:#?}");
-    info!(
-        "engine time: {:?} = {}",
-        sim,
-        EngineTime::to_float(sim)
-    );
+    info!("engine time: {:?} = {}", sim, EngineTime::to_float(sim));
 }
 
 /// call function with handle
@@ -108,7 +111,7 @@ unsafe impl RefRepr for PlayerPuppet {
 }
 
 /// define a binding for a native struct type
-/// 
+///
 /// see [RED4ext.SDK](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/Generated/EngineTime.hpp)
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]

--- a/red4ext-sys/cpp/glue/glue.hpp
+++ b/red4ext-sys/cpp/glue/glue.hpp
@@ -94,4 +94,24 @@ namespace glue {
     }
     return nullptr;
   }
+
+  CClassStaticFunction* GetStaticMethod(const CClass& cls, const CName& funcName)
+  {
+    if (&cls)
+    {
+        for (auto func : (&cls)->staticFuncs)
+        {
+            if (func->shortName == funcName || func->fullName == funcName)
+            {
+                return func;
+            }
+        }
+
+        if ((&cls)->parent)
+        {
+            return GetStaticMethod(*(&cls)->parent, funcName);
+        }
+    }
+    return nullptr;
+  }
 }

--- a/red4ext-sys/src/lib.rs
+++ b/red4ext-sys/src/lib.rs
@@ -23,6 +23,7 @@ pub mod ffi {
         type CBaseFunction;
         type CGlobalFunction;
         type CClassFunction;
+        type CClassStaticFunction;
         #[cxx_name = "IRTTISystem"]
         type IRttiSystem;
         #[cxx_name = "CBaseRTTIType"]
@@ -141,5 +142,8 @@ pub mod ffi {
 
         #[cxx_name = "GetMethod"]
         fn get_method(cls: &CClass, name: &CName) -> *mut CClassFunction;
+
+        #[cxx_name = "GetStaticMethod"]
+        fn get_static_method(cls: &CClass, name: &CName) -> *mut CClassStaticFunction;
     }
 }

--- a/red4ext/src/invocable.rs
+++ b/red4ext/src/invocable.rs
@@ -79,7 +79,15 @@ macro_rules! call {
         match $crate::call_direct!(
             rtti,
             $crate::types::RefShared::null(),
-            rtti.get_function($crate::types::CName::new($fn_name)),
+            match rtti.get_function($crate::types::CName::new($fn_name)) {
+                global if !global.is_null() => global,
+                _ => match ($fn_name.splitn(2, ':').next(), $fn_name.rsplitn(2, ':').next()) {
+                    (Some(cls), Some(func)) => $crate::rtti::Rtti::get_static_method(
+                        rtti.get_type(CName::new(cls)) as *const $crate::ffi::CClass,
+                        CName::new(func)),
+                    _ => ::std::ptr::null_mut(),
+                },
+            },
             ($($args),*) -> $rett
         ) {
             Ok(res) => res,

--- a/red4ext/src/rtti.rs
+++ b/red4ext/src/rtti.rs
@@ -43,6 +43,10 @@ impl<'a> Rtti<'a> {
         }
     }
 
+    pub fn get_static_method(typ: *const ffi::CClass, fn_name: CName) -> *mut ffi::CBaseFunction {
+        unsafe { ffi::get_static_method(&*typ, &fn_name) as _ }
+    }
+
     pub fn register_function(
         &mut self,
         name: &str,


### PR DESCRIPTION
This fixes #19.

Waiting for @psiberx approbation to reuse code from [GetStaticFunction](https://github.com/psiberx/cp2077-codeware/blob/main/lib/Red/TypeInfo/Invocation.hpp#L37) from [Codeware's Reflection API](https://github.com/psiberx/cp2077-codeware/wiki#reflection) in `glue.hpp`.

p.s: I omitted the check for [IsFakeStatic](https://github.com/psiberx/cp2077-codeware/blob/main/lib/Red/TypeInfo/Invocation.hpp#L9-L14) for `TDBIDHelper`, let me know if it's necessary or if it needs to be explicitly stated (raise a compile-time error ?).

