### PR TITLE
impl into repr for manually drop

### DIFF
--- a/red4ext/src/conv.rs
+++ b/red4ext/src/conv.rs
@@ -67,6 +67,14 @@ impl<A: NativeRepr> IntoRepr for A {
     }
 }
 
+impl<A: NativeRepr> IntoRepr for std::mem::ManuallyDrop<A> {
+    type Repr = A;
+
+    fn into_repr(mut self) -> Self::Repr {
+        unsafe { std::mem::ManuallyDrop::<A>::take(&mut self) }
+    }
+}
+
 impl IntoRepr for String {
     type Repr = RedString;
 


### PR DESCRIPTION
Prevent crash in scenario where `native struct` contains types `impl Drop` is sent from Rust to Redscript.
e.g.
```swift
struct Data {
   let values: array<Float>;
}
```
```rs
#[derive(Default)]
#[repr(C)]
struct Data {
   values: ManuallyDrop<RedArray<f32>>, // ensures values won't get dropped after being sent to Redscript
}
unsafe impl NativeRepr for Data {
    const NAME: &'static str = "Data";
}
```
