### PR TITLE
feat: tdbid as u64

### DIFF
--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -140,9 +140,7 @@ pub struct TweakDbId {
 
 impl From<u64> for TweakDbId {
     fn from(value: u64) -> Self {
-        let [b1, b2, b3, b4, length, ..] = value.to_ne_bytes();
-        let hash = u32::from_ne_bytes([b1, b2, b3, b4]);
-        Self { hash, length }
+        Self::from_u64(value)
     }
 }
 
@@ -174,6 +172,13 @@ impl TweakDbId {
         buf[3] = b4;
         buf[4] = self.length;
         u64::from_ne_bytes(buf)
+    }
+
+    #[doc(hidden)]
+    pub const fn from_u64(value: u64) -> Self {
+        let [b1, b2, b3, b4, length, ..] = value.to_ne_bytes();
+        let hash = u32::from_ne_bytes([b1, b2, b3, b4]);
+        Self { hash, length }
     }
 }
 

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -164,6 +164,17 @@ impl TweakDbId {
             length: str.len() as u8 + base.length,
         }
     }
+
+    pub const fn as_u64(&self) -> u64 {
+        let mut buf = [0u8; 8];
+        let [b1, b2, b3, b4] = self.hash.to_ne_bytes();
+        buf[0] = b1;
+        buf[1] = b2;
+        buf[2] = b3;
+        buf[3] = b4;
+        buf[4] = self.length;
+        u64::from_ne_bytes(buf)
+    }
 }
 
 unsafe impl ExternType for TweakDbId {
@@ -467,6 +478,10 @@ mod tests {
         assert_eq!(
             TweakDbId::new("Items.FirstAidWhiffV0"),
             TweakDbId::from(90_628_141_458)
+        );
+        assert_eq!(
+            TweakDbId::new("Items.FirstAidWhiffV0").as_u64(),
+            90_628_141_458
         );
         assert_eq!(
             ItemId::new_from(TweakDbId::new("Items.FirstAidWhiffV0")).get_tdbid(),


### PR DESCRIPTION
Small additions to `TweakDbId` :

- add `as_u64()` method to allow e.g. to create _newtype_ that can implement `Hash` and be used in `HashMap` like:
```rs
#[derive(PartialEq, Eq)]
pub struct Id(TweakDbId);
impl std::hash::Hash for Id {
    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
        self.0.as_u64().hash(state);
    }
}
```
- also add `from_u64` to allow creating `TweakDbId` from `u64` in `const` context if necessary.