### PR TITLE
Fix crash with latest red4ext RTTISystem

### DIFF
--- a/red4ext-sys/cpp/glue/glue.hpp
+++ b/red4ext-sys/cpp/glue/glue.hpp
@@ -45,8 +45,10 @@ void AddRTTICallback(
     const VoidPtr aPostRegFunc,
     bool aUnused)
 {
-    RTTIRegistrator::Add((RTTIRegistrator::CallbackFunc)aRegFunc,
-        (RTTIRegistrator::CallbackFunc)aPostRegFunc, aUnused);
+    IRTTISystem* rtti = GetRTTI();
+
+    rtti->AddRegisterCallback((RTTIRegistrator::CallbackFunc)aRegFunc);
+    rtti->AddPostRegisterCallback((RTTIRegistrator::CallbackFunc)aPostRegFunc);
 }
 
 void ConstructStringAt(


### PR DESCRIPTION
Fixes CTD on load with `RTTIRegistrator::Add` function. Switches to `AddRegisterCallback` and `AddPostRegisterCallback` from `IRTTISystem` instead.