### PR TITLE
Add convenience trait impls for CName

### DIFF
--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -37,15 +37,9 @@ impl CName {
     }
 }
 
-impl AsRef<str> for CName {
-    fn as_ref(&self) -> &str {
-        crate::ffi::resolve_cname(self)
-    }
-}
-
-impl ToString for CName {
-    fn to_string(&self) -> String {
-        self.as_ref().to_string()
+impl std::fmt::Display for CName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", crate::ffi::resolve_cname(self))
     }
 }
 

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -37,6 +37,7 @@ impl CName {
     }
 }
 
+#[cfg(not(test))] // only available in-game
 impl std::fmt::Display for CName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", crate::ffi::resolve_cname(self))

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -37,6 +37,18 @@ impl CName {
     }
 }
 
+impl AsRef<str> for CName {
+    fn as_ref(&self) -> &str {
+        crate::ffi::resolve_cname(self)
+    }
+}
+
+impl ToString for CName {
+    fn to_string(&self) -> String {
+        self.as_ref().to_string()
+    }
+}
+
 pub const fn fnv1a64(str: &str) -> u64 {
     const PRIME: u64 = 0x0100_0000_01b3;
     const SEED: u64 = 0xCBF2_9CE4_8422_2325;


### PR DESCRIPTION
2 simple traits impl for `CName` :
- `AsRef<str>`
- `ToString`

Concerning safety, I assumed from `resolve_cname` signature that `AsRef<str>` is safe since it returns a `&'static str`, but let me know if there's any concern with it. Otherwise having simply `ToString` will already improve ergonomics a bit :)