### PR TITLE
Register new CName / CName as Hash

### DIFF
--- a/red4ext-sys/Cargo.toml
+++ b/red4ext-sys/Cargo.toml
@@ -11,7 +11,6 @@ thiserror = "1"
 num_enum = { version = "0.7", default-features = false }
 cxx = "1"
 const-crc32 = "1"
-const-str = "0.5.6"
 
 [build-dependencies]
 cxx-build = "1"

--- a/red4ext-sys/Cargo.toml
+++ b/red4ext-sys/Cargo.toml
@@ -11,6 +11,7 @@ thiserror = "1"
 num_enum = { version = "0.7", default-features = false }
 cxx = "1"
 const-crc32 = "1"
+const-str = "0.5.6"
 
 [build-dependencies]
 cxx-build = "1"

--- a/red4ext-sys/cpp/glue/glue.hpp
+++ b/red4ext-sys/cpp/glue/glue.hpp
@@ -132,9 +132,19 @@ const CBaseRTTIType* GetPropertyType(const CProperty* prop)
     return prop->type;
 }
 
+bool ExistsCName(const CName& cname)
+{
+    return strlen(CNamePool::Get(cname)) > 0;
+}
+
 rust::Str ResolveCName(const CName& cname)
 {
     return rust::Str(CNamePool::Get(cname));
+}
+
+CName AddCName(rust::Str text)
+{
+    return CNamePool::Add(std::string(text).c_str());
 }
 
 CClassFunction* GetMethod(const CClass& cls, const CName& fullName)

--- a/red4ext-sys/cpp/glue/glue.hpp
+++ b/red4ext-sys/cpp/glue/glue.hpp
@@ -132,11 +132,6 @@ const CBaseRTTIType* GetPropertyType(const CProperty* prop)
     return prop->type;
 }
 
-bool ExistsCName(const CName& cname)
-{
-    return strlen(CNamePool::Get(cname)) > 0;
-}
-
 rust::Str ResolveCName(const CName& cname)
 {
     return rust::Str(CNamePool::Get(cname));

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -45,10 +45,10 @@ impl From<CName> for u64 {
 impl CName {
     #[inline]
     pub const fn new(str: &str) -> Self {
-        if const_str::equal!(str, "None") {
-            return Self { hash: 0 };
+        match str.as_bytes() {
+            b"None" => Self { hash: 0 },
+            _ => Self { hash: fnv1a64(str) },
         }
-        Self { hash: fnv1a64(str) }
     }
 
     pub fn new_pooled(str: &str) -> Self {

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -51,10 +51,7 @@ impl CName {
         Self { hash: fnv1a64(str) }
     }
 
-    pub fn add(str: &str) -> Self {
-        if str.is_empty() || str == "None" {
-            return Self { hash: 0 };
-        }
+    pub fn new_pooled(str: &str) -> Self {
         let cname = Self::new(str);
         if cname.is_valid() {
             return cname;

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -47,9 +47,13 @@ impl CName {
     }
 
     pub fn add(str: &str) -> Self {
-        if str.is_empty() { return Self { hash: 0 }; }
+        if str.is_empty() {
+            return Self { hash: 0 };
+        }
         let cname = Self::new(str);
-        if crate::ffi::exists_cname(&cname) { return cname; }
+        if crate::ffi::exists_cname(&cname) {
+            return cname;
+        }
         let created = crate::ffi::add_cname(str);
         assert_eq!(created, cname);
         created

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -507,7 +507,7 @@ mod tests {
         assert_eq!(CName::new("Vector2").hash, 7_466_804_955_052_523_504);
         assert_eq!(CName::new("Color").hash, 3_769_135_706_557_701_272);
         assert_eq!(CName::new("None").hash, 0);
-        assert_eq!(CName::new("").hash, 0xCBF29CE484222325);
+        assert_eq!(CName::new("").hash, 0xCBF2_9CE4_8422_2325);
     }
 
     #[test]

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -507,6 +507,7 @@ mod tests {
         assert_eq!(CName::new("Vector2").hash, 7_466_804_955_052_523_504);
         assert_eq!(CName::new("Color").hash, 3_769_135_706_557_701_272);
         assert_eq!(CName::new("None").hash, 0);
+        assert_eq!(CName::new("").hash, 0xCBF29CE484222325);
     }
 
     #[test]

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -45,6 +45,15 @@ impl CName {
     pub const fn to_u64(self) -> u64 {
         self.hash
     }
+
+    pub fn add(str: &str) -> Self {
+        if str.is_empty() { return Self { hash: 0 }; }
+        let cname = Self::new(str);
+        if crate::ffi::exists_cname(&cname) { return cname; }
+        let created = crate::ffi::add_cname(str);
+        assert_eq!(created, cname);
+        created
+    }
 }
 
 #[cfg(not(test))] // only available in-game

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -51,12 +51,16 @@ impl CName {
             return Self { hash: 0 };
         }
         let cname = Self::new(str);
-        if crate::ffi::exists_cname(&cname) {
+        if cname.is_valid() {
             return cname;
         }
         let created = crate::ffi::add_cname(str);
         assert_eq!(created, cname);
         created
+    }
+
+    pub fn is_valid(&self) -> bool {
+        !crate::ffi::resolve_cname(self).is_empty()
     }
 }
 

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -45,6 +45,9 @@ impl From<CName> for u64 {
 impl CName {
     #[inline]
     pub const fn new(str: &str) -> Self {
+        if const_str::equal!(str, "None") {
+            return Self { hash: 0 };
+        }
         Self { hash: fnv1a64(str) }
     }
 
@@ -506,6 +509,7 @@ mod tests {
         assert_eq!(CName::new("IScriptable").hash, 3_191_163_302_135_919_211);
         assert_eq!(CName::new("Vector2").hash, 7_466_804_955_052_523_504);
         assert_eq!(CName::new("Color").hash, 3_769_135_706_557_701_272);
+        assert_eq!(CName::new("None").hash, 0);
     }
 
     #[test]

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -47,7 +47,7 @@ impl CName {
     }
 
     pub fn add(str: &str) -> Self {
-        if str.is_empty() {
+        if str.is_empty() || str == "None" {
             return Self { hash: 0 };
         }
         let cname = Self::new(str);

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -30,10 +30,20 @@ pub struct CName {
     hash: u64,
 }
 
+impl From<u64> for CName {
+    fn from(hash: u64) -> Self {
+        Self { hash }
+    }
+}
+
 impl CName {
     #[inline]
     pub const fn new(str: &str) -> Self {
         Self { hash: fnv1a64(str) }
+    }
+
+    pub const fn to_u64(self) -> u64 {
+        self.hash
     }
 }
 

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -51,6 +51,7 @@ impl CName {
         }
     }
 
+    #[cfg(not(test))] // only available in-game
     pub fn new_pooled(str: &str) -> Self {
         let cname = Self::new(str);
         if cname.is_valid() {
@@ -61,6 +62,7 @@ impl CName {
         created
     }
 
+    #[cfg(not(test))] // only available in-game
     pub fn is_valid(&self) -> bool {
         !crate::ffi::resolve_cname(self).is_empty()
     }

--- a/red4ext-sys/src/interop.rs
+++ b/red4ext-sys/src/interop.rs
@@ -36,14 +36,16 @@ impl From<u64> for CName {
     }
 }
 
+impl From<CName> for u64 {
+    fn from(value: CName) -> Self {
+        value.hash
+    }
+}
+
 impl CName {
     #[inline]
     pub const fn new(str: &str) -> Self {
         Self { hash: fnv1a64(str) }
-    }
-
-    pub const fn to_u64(self) -> u64 {
-        self.hash
     }
 
     pub fn add(str: &str) -> Self {

--- a/red4ext-sys/src/lib.rs
+++ b/red4ext-sys/src/lib.rs
@@ -159,9 +159,6 @@ pub mod ffi {
         #[cxx_name = "GetPropertyType"]
         unsafe fn get_property_type(prop: *const CProperty) -> *const CBaseRttiType;
 
-        #[cxx_name = "ExistsCName"]
-        fn exists_cname(cname: &CName) -> bool;
-
         #[cxx_name = "ResolveCName"]
         fn resolve_cname(cname: &CName) -> &'static str;
 

--- a/red4ext-sys/src/lib.rs
+++ b/red4ext-sys/src/lib.rs
@@ -159,8 +159,14 @@ pub mod ffi {
         #[cxx_name = "GetPropertyType"]
         unsafe fn get_property_type(prop: *const CProperty) -> *const CBaseRttiType;
 
+        #[cxx_name = "ExistsCName"]
+        fn exists_cname(cname: &CName) -> bool;
+
         #[cxx_name = "ResolveCName"]
         fn resolve_cname(cname: &CName) -> &'static str;
+
+        #[cxx_name = "AddCName"]
+        fn add_cname(text: &str) -> CName;
 
         #[cxx_name = "GetMethod"]
         fn get_method(cls: &CClass, name: &CName) -> *mut CClassFunction;


### PR DESCRIPTION
This small PR adds:
- the necessary conversion to use `CName` as `std::hash::Hash` (via newtype pattern)
- the ability to safely register new `CName` in underlying `CNamePool`

Wishing you happy end of the year's celebrations @jac3km4 :)