### PR TITLE
Update Rust toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.5.3"
-rust-version = "1.72"
+rust-version = "1.75"
 edition = "2021"
 license = "MIT"
 authors = ["jekky"]

--- a/examples/menu_button/rust-toolchain.toml
+++ b/examples/menu_button/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-10-05"
+channel = "nightly-2023-12-31"

--- a/examples/player_info/rust-toolchain.toml
+++ b/examples/player_info/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-10-05"
+channel = "nightly-2023-12-31"


### PR DESCRIPTION
Happy New Year @jac3km4, best wishes !

Simply bumps Rust toolchain to latest.
`red4ext-rs` tag version should probably be updated.
