### PR TITLE
Fix native repr name typo

### DIFF
--- a/src/repr.rs
+++ b/src/repr.rs
@@ -48,7 +48,7 @@ macro_rules! impl_native_repr {
     };
     ($ty:ty, $name:literal, $native_name:literal) => {
         unsafe impl NativeRepr for $ty {
-            const NAME: &'static str = $name;
+            const NAME: &'static str = $native_name;
         }
     };
 }


### PR DESCRIPTION
There seems to be a typo in the macro defining `NativeRepr` name.

When calling e.g. 
```swift
module My
private func Func(a: CName, b: EntityID, c: CName) -> Void;
```
like
```rs
if let Err(e) = call!("My.Func;CNameEntityIDCName"(a, b, c) -> ()) { ... }
```
Here's the error in log:
```
could not resolve type EntityID
```

Switching to native name fixes it.