### PR TITLE
Allow to rewind stack

### DIFF
--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -154,7 +154,7 @@ impl StackFrame {
     ///     }
     /// }
     /// ```
-    pub unsafe fn rewind(&mut self, state: StackState) {
+    pub unsafe fn restore_args(&mut self, state: StackState) {
         self.0.code = state.code;
         self.0.data = state.data;
         self.0.dataType = state.data_type;

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -96,7 +96,7 @@ impl StackFrame {
     ///
     /// Use its returned value
     /// with [restore_args](Self::restore_args) to restore the state of arguments.
-    pub fn arg_state(&self) -> StackArgsState {
+    pub fn args_state(&self) -> StackArgsState {
         StackArgsState {
             code: self.0.code,
             data: self.0.data,
@@ -135,7 +135,7 @@ impl StackFrame {
     ///     let frame = &mut *f;
     ///
     ///     // stack must be saved before reading stack function parameters
-    ///     let state = frame.arg_state();
+    ///     let state = frame.args_state();
     ///     
     ///     // assuming our function accepts these 3 parameters
     ///     let event_name: CName = StackFrame::get_arg(frame);

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -93,7 +93,7 @@ impl StackFrame {
     }
 
     /// Captures stack frame state.
-    /// 
+    ///
     /// Use its returned value
     /// with [rewind](Self::rewind) to restore stack.
     pub fn state(&self) -> StackState {
@@ -109,10 +109,10 @@ impl StackFrame {
     ///
     /// # Safety
     /// The state must be saved **before** reading arguments.
-    /// 
+    ///
     /// The state must be restored **before** calling callback,
     /// once arguments have been read.
-    /// 
+    ///
     /// Stack arguments should **neither** be _partially_ read,
     /// **nor** _partially_ restored.
     ///

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -92,7 +92,7 @@ impl StackFrame {
         }
     }
 
-    /// Captures stack frame state.
+    /// Captures the state of stack arguments.
     ///
     /// Use its returned value
     /// with [rewind](Self::rewind) to restore stack.

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -92,6 +92,10 @@ impl StackFrame {
         }
     }
 
+    /// Captures stack frame state.
+    /// 
+    /// Use its returned value
+    /// with [rewind](Self::rewind) to restore stack.
     pub fn state(&self) -> StackState {
         StackState {
             code: self.0.code,
@@ -105,7 +109,12 @@ impl StackFrame {
     ///
     /// # Safety
     /// The state must be saved **before** reading arguments.
-    /// The state must be restored **after** having read arguments, before calling callback.
+    /// 
+    /// The state must be restored **before** calling callback,
+    /// once arguments have been read.
+    /// 
+    /// Stack arguments should **neither** be _partially_ read,
+    /// **nor** _partially_ restored.
     ///
     /// # Example
     /// ```rust
@@ -186,6 +195,7 @@ impl<'a> StackArg<'a> {
     }
 }
 
+/// Snapshot of a stack frame state.
 pub struct StackState {
     code: *mut i8,
     data: VoidPtr,

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -109,8 +109,7 @@ impl StackFrame {
     /// # Safety
     /// The state must be saved **before** reading arguments.
     ///
-    /// The state must be restored **before** calling callback,
-    /// once arguments have been read.
+    /// The state must be restored **before** passing it back to game code.
     ///
     /// Stack arguments should **neither** be _partially_ read,
     /// **nor** _partially_ restored.

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -95,7 +95,7 @@ impl StackFrame {
     /// Captures the state of stack arguments.
     ///
     /// Use its returned value
-    /// with [rewind](Self::rewind) to restore stack.
+    /// with [restore_args](Self::restore_args) to restore the state of arguments.
     pub fn arg_state(&self) -> StackState {
         StackState {
             code: self.0.code,

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -104,8 +104,7 @@ impl StackFrame {
         }
     }
 
-    /// Allows to rewind the stack after having read function arguments,
-    /// when detoured function need to be called.
+    /// Allows to reset the state of function arguments.
     ///
     /// # Safety
     /// The state must be saved **before** reading arguments.

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -193,7 +193,7 @@ impl<'a> StackArg<'a> {
     }
 }
 
-/// Snapshot of a stack frame state.
+/// Snapshot of the state of stack arguments.
 pub struct StackState {
     code: *mut i8,
     data: VoidPtr,

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -111,7 +111,7 @@ impl StackFrame {
     /// ```rust
     /// # use red4ext_rs::{hooks, SdkEnv, types::{CName, EntityId, StackFrame, IScriptable}, VoidPtr};
     /// # hooks! {
-    /// #    static ADD_HOOK: unsafe extern "C" fn(i: *mut IScriptable, f: *mut StackFrame, a3: VoidPtr, a4: VoidPtr);
+    /// #    static ADD_HOOK: fn(i: *mut IScriptable, f: *mut StackFrame, a3: VoidPtr, a4: VoidPtr) -> ();
     /// # }
     /// # fn attach_my_hook(env: &SdkEnv, addr: unsafe extern "C" fn(i: *mut IScriptable, f: *mut StackFrame, a3: VoidPtr, a4: VoidPtr)) {
     /// #     unsafe { env.attach_hook(ADD_HOOK, addr, detour) };

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -109,14 +109,14 @@ impl StackFrame {
     ///
     /// # Example
     /// ```rust
-    /// # use red4ext_rs::{hooks, SdkEnv, types::{CName, StackFrame, IScriptable}, VoidPtr};
+    /// # use red4ext_rs::{hooks, SdkEnv, types::{CName, EntityId, StackFrame, IScriptable}, VoidPtr};
     /// # hooks! {
-    /// #    static ADD_HOOK: fn(a: u32, b: u32) -> u32;
+    /// #    static ADD_HOOK: unsafe extern "C" fn(i: *mut IScriptable, f: *mut StackFrame, a3: VoidPtr, a4: VoidPtr);
     /// # }
     /// # fn attach_my_hook(env: &SdkEnv, addr: unsafe extern "C" fn(i: *mut IScriptable, f: *mut StackFrame, a3: VoidPtr, a4: VoidPtr)) {
     /// #     unsafe { env.attach_hook(ADD_HOOK, addr, detour) };
     /// # }
-    /// # fn should_detour(event_name: CName) -> bool = false;
+    /// # fn should_detour(event_name: CName) -> bool { false }
     ///
     /// unsafe extern "C" fn detour(
     ///     i: *mut IScriptable,
@@ -141,7 +141,7 @@ impl StackFrame {
     ///         // since we've read stack function arguments,
     ///         // stack must be rewinded before callback.
     ///         frame.rewind(state);
-    ///         cb(a, b)
+    ///         cb(i, f, a3, a4);
     ///     }
     /// }
     /// ```

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -96,8 +96,8 @@ impl StackFrame {
     ///
     /// Use its returned value
     /// with [restore_args](Self::restore_args) to restore the state of arguments.
-    pub fn arg_state(&self) -> StackState {
-        StackState {
+    pub fn arg_state(&self) -> StackArgsState {
+        StackArgsState {
             code: self.0.code,
             data: self.0.data,
             data_type: self.0.dataType,
@@ -135,7 +135,7 @@ impl StackFrame {
     ///     let frame = &mut *f;
     ///
     ///     // stack must be saved before reading stack function parameters
-    ///     let state = frame.state();
+    ///     let state = frame.arg_state();
     ///     
     ///     // assuming our function accepts these 3 parameters
     ///     let event_name: CName = StackFrame::get_arg(frame);
@@ -146,13 +146,13 @@ impl StackFrame {
     ///         // do something else...
     ///     } else {
     ///         // since we've read stack function arguments,
-    ///         // stack must be rewinded before callback.
-    ///         frame.rewind(state);
+    ///         // stack arguments must be restored before callback.
+    ///         frame.restore_args(state);
     ///         cb(i, f, a3, a4);
     ///     }
     /// }
     /// ```
-    pub unsafe fn restore_args(&mut self, state: StackState) {
+    pub unsafe fn restore_args(&mut self, state: StackArgsState) {
         self.0.code = state.code;
         self.0.data = state.data;
         self.0.dataType = state.data_type;

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -145,7 +145,7 @@ impl StackFrame {
     ///     }
     /// }
     /// ```
-    pub unsafe fn rewind(mut self, state: StackState) {
+    pub unsafe fn rewind(&mut self, state: StackState) {
         self.0.code = state.code;
         self.0.data = state.data;
         self.0.dataType = state.data_type;

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -194,7 +194,7 @@ impl<'a> StackArg<'a> {
 }
 
 /// Snapshot of the state of stack arguments.
-pub struct StackState {
+pub struct StackArgsState {
     code: *mut i8,
     data: VoidPtr,
     data_type: *mut red::CBaseRTTIType,

--- a/src/types/stack.rs
+++ b/src/types/stack.rs
@@ -96,7 +96,7 @@ impl StackFrame {
     ///
     /// Use its returned value
     /// with [rewind](Self::rewind) to restore stack.
-    pub fn state(&self) -> StackState {
+    pub fn arg_state(&self) -> StackState {
         StackState {
             code: self.0.code,
             data: self.0.data,


### PR DESCRIPTION
When detouring function, it's often useful to callback the original function _or_ another function based on argument(s) value.

This PR adds 2 methods for this purpose + safety recommendations, including doc.