### PR TITLE
Support class static method in call!

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use red4ext_rs::{
 fn example(player: Ref<IScriptable>) -> i32 {
     // the line below will attempt to look up a matching method in the instance and call it
     let size = call!(player, "GetDeviceActionMaxQueueSize;" () -> i32).unwrap();
-    // the lines below will attempt to look up a matching static method or global function
+    // the lines below will attempt to look up a matching static method (scripted or native) and call it
     let _ = call!("MathHelper"::"EulerNumber"() -> f32).unwrap();
     let _ = call!("PlayerPuppet"::"GetCriticalHealthThreshold" () -> f32).unwrap();
     // the line below invokes a global native function (the operator for adding two Int32)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ fn example(player: Ref<IScriptable>) -> i32 {
     // the line below will attempt to look up a matching method in the instance and call it
     let size = call!(player, "GetDeviceActionMaxQueueSize;" () -> i32).unwrap();
     // the lines below will attempt to look up a matching static method or global function
-    let _ = call!("MathHelper"::"EulerNumber"() -> f32);
+    let _ = call!("MathHelper"::"EulerNumber"() -> f32).unwrap();
     let _ = call!("PlayerPuppet"::"GetCriticalHealthThreshold" () -> f32).unwrap();
     // the line below invokes a global native function (the operator for adding two Int32)
     let added1 = call!("OperatorAdd;Int32Int32;Int32" (size, 4i32) -> i32).unwrap();

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ use red4ext_rs::{
 fn example(player: Ref<IScriptable>) -> i32 {
     // the line below will attempt to look up a matching method in the instance and call it
     let size = call!(player, "GetDeviceActionMaxQueueSize;" () -> i32).unwrap();
+    // the lines below will attempt to look up a matching static method or global function
+    let _ = call!("MathHelper"::"EulerNumber"() -> f32);
+    let _ = call!("PlayerPuppet"::"GetCriticalHealthThreshold" () -> f32).unwrap();
     // the line below invokes a global native function (the operator for adding two Int32)
     let added1 = call!("OperatorAdd;Int32Int32;Int32" (size, 4i32) -> i32).unwrap();
     added1

--- a/src/invocable.rs
+++ b/src/invocable.rs
@@ -15,8 +15,6 @@ use crate::VoidPtr;
 /// An error returned when invoking a function fails.
 #[derive(Debug, Error)]
 pub enum InvokeError {
-    #[error("class could not be found by native name '{0}'")]
-    ClassNotFound(&'static str),
     #[error("function could not be found by full name '{0}'")]
     FunctionNotFound(&'static str),
     #[error(

--- a/src/invocable.rs
+++ b/src/invocable.rs
@@ -348,9 +348,8 @@ macro_rules! call {
     ($cls_name:literal :: $fn_name:literal ($( $args:expr ),*) -> $rett:ty) => {
         (|| {
             $crate::RttiSystem::get()
-                .resolve_static_by_full_name($crate::types::CName::new(::std::concat!($cls_name, "::", $fn_name)))
+                .resolve_static_by_full_name(::std::concat!($cls_name, "::", $fn_name))
                 .ok_or($crate::InvokeError::FunctionNotFound($fn_name))?
-                .as_function()
                 .execute::<_, $rett>(None, ($( $crate::IntoRepr::into_repr($args), )*))
         })()
     };

--- a/src/invocable.rs
+++ b/src/invocable.rs
@@ -357,6 +357,7 @@ macro_rules! call {
                 .find(|x| x.as_function().name() == $crate::types::CName::new($fn_name)
                 || x.as_function().short_name() == $crate::types::CName::new($fn_name))
                 .ok_or($crate::InvokeError::FunctionNotFound($fn_name))?
+                .as_function()
                 .execute::<_, $rett>(None, ($( $crate::IntoRepr::into_repr($args), )*))
         })()
     };

--- a/src/invocable.rs
+++ b/src/invocable.rs
@@ -350,12 +350,7 @@ macro_rules! call {
     ($cls_name:literal :: $fn_name:literal ($( $args:expr ),*) -> $rett:ty) => {
         (|| {
             $crate::RttiSystem::get()
-                .get_class($crate::types::CName::new($cls_name))
-                .ok_or($crate::InvokeError::ClassNotFound($cls_name))?
-                .static_methods()
-                .iter()
-                .find(|x| x.as_function().name() == $crate::types::CName::new($fn_name)
-                || x.as_function().short_name() == $crate::types::CName::new($fn_name))
+                .resolve_static_by_full_name($crate::types::CName::new(::std::concat!($cls_name, "::", $fn_name)))
                 .ok_or($crate::InvokeError::FunctionNotFound($fn_name))?
                 .as_function()
                 .execute::<_, $rett>(None, ($( $crate::IntoRepr::into_repr($args), )*))


### PR DESCRIPTION
Allow to `call!` a class static method like so:
```rs
let from: Vector4 = ...;
let to: Vector4 = ...;
call!("Vector4"::"Distance"(from, to) -> f32);
```