### PR TITLE
Inner ref as convenience

### DIFF
--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -91,6 +91,28 @@ impl<T: ScriptClass> Ref<T> {
     pub fn is_null(&self) -> bool {
         self.0 .0.instance.is_null()
     }
+
+    #[inline]
+    pub fn is_exactly_a<U>(&self) -> bool
+    where
+        U: ScriptClass,
+    {
+        !self.is_null()
+            && unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
+                .unwrap()
+                .is_exactly_a::<U>()
+    }
+
+    #[inline]
+    pub fn is_a<U>(&self) -> bool
+    where
+        U: ScriptClass,
+    {
+        !self.is_null()
+            && unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
+                .unwrap()
+                .is_a::<U>()
+    }
 }
 
 impl<T: ScriptClass> Default for Ref<T> {

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -98,8 +98,7 @@ impl<T: ScriptClass> Ref<T> {
         U: ScriptClass,
     {
         unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
-            .unwrap()
-            .is_exactly_a::<U>()
+            .is_some_and(|x| x.is_exactly_a::<U>())
     }
 
     #[inline]
@@ -108,8 +107,7 @@ impl<T: ScriptClass> Ref<T> {
         U: ScriptClass,
     {
         unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
-            .unwrap()
-            .is_a::<U>()
+            .is_some_and(|x| x.is_a::<U>())
     }
 }
 

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -83,10 +83,7 @@ impl<T: ScriptClass> Ref<T> {
         U: ScriptClass,
     {
         let inst = unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }?;
-        inst.class()
-            .base_iter_with_self()
-            .any(|class| class.name() == CName::new(U::NAME))
-            .then(|| unsafe { mem::transmute(self) })
+        inst.is_a::<U>().then(|| unsafe { mem::transmute(self) })
     }
 
     /// Returns whether the reference is null.

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -107,8 +107,7 @@ impl<T: ScriptClass> Ref<T> {
     where
         U: ScriptClass,
     {
-        !self.is_null()
-            && unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
+            unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
                 .unwrap()
                 .is_a::<U>()
     }

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -98,7 +98,7 @@ impl<T: ScriptClass> Ref<T> {
         U: ScriptClass,
     {
         unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
-            .is_some_and(|x| x.is_exactly_a::<U>())
+            .is_some_and(ISerializable::is_exactly_a::<U>)
     }
 
     #[inline]
@@ -107,7 +107,7 @@ impl<T: ScriptClass> Ref<T> {
         U: ScriptClass,
     {
         unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
-            .is_some_and(|x| x.is_a::<U>())
+            .is_some_and(ISerializable::is_a::<U>)
     }
 }
 

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -97,8 +97,7 @@ impl<T: ScriptClass> Ref<T> {
     where
         U: ScriptClass,
     {
-        !self.is_null()
-            && unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
+            unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
                 .unwrap()
                 .is_exactly_a::<U>()
     }

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -97,9 +97,9 @@ impl<T: ScriptClass> Ref<T> {
     where
         U: ScriptClass,
     {
-            unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
-                .unwrap()
-                .is_exactly_a::<U>()
+        unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
+            .unwrap()
+            .is_exactly_a::<U>()
     }
 
     #[inline]
@@ -107,9 +107,9 @@ impl<T: ScriptClass> Ref<T> {
     where
         U: ScriptClass,
     {
-            unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
-                .unwrap()
-                .is_a::<U>()
+        unsafe { (self.0 .0.instance as *const ISerializable).as_ref() }
+            .unwrap()
+            .is_a::<U>()
     }
 }
 

--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -4,8 +4,8 @@ use std::ptr::NonNull;
 use std::{fmt, iter, mem, ptr, slice};
 
 use super::{
-    CName, CNamePool, IAllocator, PoolRef, PoolableOps, RedArray, RedHashMap, RedString,
-    StackArg, StackFrame, WeakRef,
+    CName, CNamePool, IAllocator, PoolRef, PoolableOps, RedArray, RedHashMap, RedString, StackArg,
+    StackFrame, WeakRef,
 };
 use crate::invocable::{Args, InvokeError};
 use crate::raw::root::RED4ext as red;

--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -1437,15 +1437,15 @@ impl ISerializable {
     }
 
     #[inline]
-    pub fn inner_ref<U>(&self) -> WeakRef<U>
+    pub fn inner_ref<U>(&self) -> Option<WeakRef<U>>
     where
         U: ScriptClass,
     {
-        if !self.is_a::<U>() {
-            return WeakRef::default();
-        }
-        unsafe { mem::transmute::<&red::WeakHandle<red::ISerializable>, &WeakRef<U>>(&self.0.ref_) }
-            .clone()
+        self.is_a::<U>()
+          .then(||
+            unsafe { mem::transmute::<&red::WeakHandle<red::ISerializable>, &WeakRef<U>>(&self.0.ref_) }
+              .clone()
+          )
     }
 }
 

--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -1441,11 +1441,12 @@ impl ISerializable {
     where
         U: ScriptClass,
     {
-        self.is_a::<U>()
-          .then(||
-            unsafe { mem::transmute::<&red::WeakHandle<red::ISerializable>, &WeakRef<U>>(&self.0.ref_) }
-              .clone()
-          )
+        self.is_a::<U>().then(|| {
+            unsafe {
+                mem::transmute::<&red::WeakHandle<red::ISerializable>, &WeakRef<U>>(&self.0.ref_)
+            }
+            .clone()
+        })
     }
 }
 


### PR DESCRIPTION
Allows to retrieve a `WeakRef<T>` from an `&T: ScriptClass`.
+ refactor `cast` inner logic into `is_a`, adding `is_exactly_a` alongside.

It's a bit weird when compared to Redscript to have to reach the inner `instance` of a `ref<IScriptable>` to be able to use `IsA` and `IsExactlyA`, so it could be a good idea to expose it on `Ref<IScriptable>` as a convenience ?