### PR TITLE
Semver changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,23 +45,4 @@ fn main() {
         "cargo:warning=Generated bindings: {}",
         out_path.join("bindings.rs").display()
     );
-
-    const SIZE: usize = 512;
-    let mut sizes = String::with_capacity(11264); // increase according to size (SIZE)
-    sizes.push_str("pub const fn const_digit_str(x: usize) -> &'static str {");
-    sizes.push_str("\n    match x {");
-    for i in 1..=SIZE {
-        sizes.push_str("\n        ");
-        sizes.push_str(i.to_string().as_str());
-        sizes.push_str(" => ");
-        sizes.push('"');
-        sizes.push_str(i.to_string().as_str());
-        sizes.push('"');
-        sizes.push(',');
-    }
-    sizes.push_str("\n      _ => unimplemented!()");
-    sizes.push_str("\n    }");
-    sizes.push('\n');
-    sizes.push('}');
-    std::fs::write(out_path.join("sizes.rs"), sizes).expect("Couldn't write const_digit_str!");
 }

--- a/build.rs
+++ b/build.rs
@@ -45,4 +45,23 @@ fn main() {
         "cargo:warning=Generated bindings: {}",
         out_path.join("bindings.rs").display()
     );
+
+    const SIZE: usize = 512;
+    let mut sizes = String::with_capacity(11264); // increase according to size (SIZE)
+    sizes.push_str("pub const fn const_digit_str(x: usize) -> &'static str {");
+    sizes.push_str("\n    match x {");
+    for i in 1..=SIZE {
+        sizes.push_str("\n        ");
+        sizes.push_str(i.to_string().as_str());
+        sizes.push_str(" => ");
+        sizes.push('"');
+        sizes.push_str(i.to_string().as_str());
+        sizes.push('"');
+        sizes.push(',');
+    }
+    sizes.push_str("\n      _ => unimplemented!()");
+    sizes.push_str("\n    }");
+    sizes.push('\n');
+    sizes.push('}');
+    std::fs::write(out_path.join("sizes.rs"), sizes).expect("Couldn't write const_digit_str!");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,9 +543,9 @@ impl fmt::Display for red::v0::SemVer_PrereleaseInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.type_ {
             OFFICIAL => write!(f, ""),
-            ALPHA => write!(f, "alpha+{}", self.number),
-            BETA => write!(f, "beta+{}", self.number),
-            RC => write!(f, "rc+{}", self.number),
+            ALPHA => write!(f, "alpha.{}", self.number),
+            BETA => write!(f, "beta.{}", self.number),
+            RC => write!(f, "rc.{}", self.number),
             _ => unimplemented!(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,25 @@ impl fmt::Display for red::v0::SemVer_PrereleaseInfo {
     }
 }
 
+impl From<SemVer> for [u32; 5] {
+    fn from(
+        SemVer(red::SemVer {
+            major,
+            minor,
+            patch,
+            prerelease,
+        }): SemVer,
+    ) -> Self {
+        [
+            major as u32,
+            minor as u32,
+            patch,
+            prerelease.type_,
+            prerelease.number,
+        ]
+    }
+}
+
 /// A version number representing the game's version.
 #[derive(Debug)]
 pub struct RuntimeVersion(red::FileVer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,62 +466,22 @@ impl log::Log for SdkEnv {
 #[derive(Debug)]
 pub struct SemVer(red::SemVer);
 
-const OFFICIAL: u32 = 0;
-const ALPHA: u32 = 1;
-const BETA: u32 = 2;
-const RC: u32 = 3;
-
 impl SemVer {
     /// Creates a new semantic version.
     #[inline]
     pub const fn new(major: u8, minor: u16, patch: u32) -> Self {
-        Self::exact(major, minor, patch, OFFICIAL, 0)
+        Self::exact(major, minor, patch, 0, 0)
     }
 
-    /// Creates a new alpha version.
+    /// Creates a new exact semantic version.
     #[inline]
-    pub const fn alpha(major: u8, minor: u16, patch: u32, number: u32) -> Self {
-        Self::exact(major, minor, patch, ALPHA, number)
-    }
-
-    /// Creates a new beta version.
-    #[inline]
-    pub const fn beta(major: u8, minor: u16, patch: u32, number: u32) -> Self {
-        Self::exact(major, minor, patch, BETA, number)
-    }
-
-    /// Creates a new release candidate version.
-    #[inline]
-    pub const fn rc(major: u8, minor: u16, patch: u32, number: u32) -> Self {
-        Self::exact(major, minor, patch, RC, number)
-    }
-
-    #[inline]
-    const fn exact(major: u8, minor: u16, patch: u32, type_: u32, number: u32) -> Self {
+    pub const fn exact(major: u8, minor: u16, patch: u32, type_: u32, number: u32) -> Self {
         Self(red::SemVer {
             major,
             minor,
             patch,
             prerelease: red::v0::SemVer_PrereleaseInfo { type_, number },
         })
-    }
-
-    const fn is_prerelease(&self) -> bool {
-        self.0.prerelease.type_ > OFFICIAL
-    }
-}
-
-impl fmt::Display for SemVer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_prerelease() {
-            write!(
-                f,
-                "{}.{}.{}-{}",
-                self.0.major, self.0.minor, self.0.patch, self.0.prerelease
-            )
-        } else {
-            write!(f, "{}.{}.{}", self.0.major, self.0.minor, self.0.patch)
-        }
     }
 }
 
@@ -532,41 +492,10 @@ impl IntoRepr for SemVer {
         Self::Repr::from_iter([
             self.0.major as u32,
             self.0.minor as u32,
-            self.0.patch as u32,
-            self.0.prerelease.type_ as u32,
-            self.0.prerelease.number as u32,
+            self.0.patch,
+            self.0.prerelease.type_,
+            self.0.prerelease.number,
         ])
-    }
-}
-
-impl fmt::Display for red::v0::SemVer_PrereleaseInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.type_ {
-            OFFICIAL => write!(f, ""),
-            ALPHA => write!(f, "alpha.{}", self.number),
-            BETA => write!(f, "beta.{}", self.number),
-            RC => write!(f, "rc.{}", self.number),
-            _ => unimplemented!(),
-        }
-    }
-}
-
-impl From<SemVer> for [u32; 5] {
-    fn from(
-        SemVer(red::SemVer {
-            major,
-            minor,
-            patch,
-            prerelease,
-        }): SemVer,
-    ) -> Self {
-        [
-            major as u32,
-            minor as u32,
-            patch,
-            prerelease.type_,
-            prerelease.number,
-        ]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use export::{
 };
 use raw::root::{versioning, RED4ext as red};
 use sealed::sealed;
-use types::RedArray;
+use types::{RedArray, StaticArray};
 pub use widestring::{widecstr as wcstr, U16CStr};
 
 mod class;
@@ -485,19 +485,39 @@ impl SemVer {
     }
 }
 
-impl IntoRepr for SemVer {
-    type Repr = RedArray<u32>;
-
-    fn into_repr(self) -> Self::Repr {
-        Self::Repr::from_iter([
-            self.0.major as u32,
-            self.0.minor as u32,
-            self.0.patch,
-            self.0.prerelease.type_,
-            self.0.prerelease.number,
+impl From<SemVer> for StaticArray<u16, 3> {
+    fn from(value: SemVer) -> Self {
+        Self::from([
+            value.0.major as u16,
+            value.0.minor as u16,
+            value.0.patch as u16,
         ])
     }
 }
+
+impl From<SemVer> for StaticArray<u32, 5> {
+    fn from(value: SemVer) -> Self {
+        Self::from([
+            value.0.major as u32,
+            value.0.minor as u32,
+            value.0.patch,
+            value.0.prerelease.type_,
+            value.0.prerelease.number,
+        ])
+    }
+}
+
+// impl IntoRepr for SemVer {
+//     type Repr = StaticArray<u16, 3>;
+
+//     fn into_repr(self) -> Self::Repr {
+//         Self::Repr::from([
+//             self.0.major as u16,
+//             self.0.minor as u16,
+//             self.0.patch as u16,
+//         ])
+//     }
+// }
 
 /// A version number representing the game's version.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use export::{
 };
 use raw::root::{versioning, RED4ext as red};
 use sealed::sealed;
+use types::RedArray;
 pub use widestring::{widecstr as wcstr, U16CStr};
 
 mod class;
@@ -521,6 +522,20 @@ impl fmt::Display for SemVer {
         } else {
             write!(f, "{}.{}.{}", self.0.major, self.0.minor, self.0.patch)
         }
+    }
+}
+
+impl IntoRepr for SemVer {
+    type Repr = RedArray<u32>;
+
+    fn into_repr(self) -> Self::Repr {
+        Self::Repr::from_iter([
+            self.0.major as u32,
+            self.0.minor as u32,
+            self.0.patch as u32,
+            self.0.prerelease.type_ as u32,
+            self.0.prerelease.number as u32,
+        ])
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use export::{
 };
 use raw::root::{versioning, RED4ext as red};
 use sealed::sealed;
-use types::{RedArray, StaticArray};
+use types::StaticArray;
 pub use widestring::{widecstr as wcstr, U16CStr};
 
 mod class;
@@ -487,37 +487,33 @@ impl SemVer {
 
 impl From<SemVer> for StaticArray<u16, 3> {
     fn from(value: SemVer) -> Self {
-        Self::from([
-            value.0.major as u16,
-            value.0.minor as u16,
-            value.0.patch as u16,
-        ])
+        Self::from([value.0.major as u16, value.0.minor, value.0.patch as u16])
     }
 }
 
-impl From<SemVer> for StaticArray<u32, 5> {
+impl From<SemVer> for StaticArray<u16, 5> {
     fn from(value: SemVer) -> Self {
         Self::from([
-            value.0.major as u32,
-            value.0.minor as u32,
-            value.0.patch,
-            value.0.prerelease.type_,
-            value.0.prerelease.number,
+            value.0.major as u16,
+            value.0.minor,
+            value.0.patch as u16,
+            value.0.prerelease.type_ as u16,
+            value.0.prerelease.number as u16,
         ])
     }
 }
 
-// impl IntoRepr for SemVer {
-//     type Repr = StaticArray<u16, 3>;
+impl IntoRepr for SemVer {
+    type Repr = StaticArray<u16, 3>;
 
-//     fn into_repr(self) -> Self::Repr {
-//         Self::Repr::from([
-//             self.0.major as u16,
-//             self.0.minor as u16,
-//             self.0.patch as u16,
-//         ])
-//     }
-// }
+    fn into_repr(self) -> Self::Repr {
+        Self::Repr::from([
+            self.0.major as u16,
+            self.0.minor,
+            self.0.patch as u16,
+        ])
+    }
+}
 
 /// A version number representing the game's version.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,11 +507,7 @@ impl IntoRepr for SemVer {
     type Repr = StaticArray<u16, 3>;
 
     fn into_repr(self) -> Self::Repr {
-        Self::Repr::from([
-            self.0.major as u16,
-            self.0.minor,
-            self.0.patch as u16,
-        ])
+        Self::Repr::from([self.0.major as u16, self.0.minor, self.0.patch as u16])
     }
 }
 
@@ -800,3 +796,5 @@ fn check_invariant(success: bool, message: &'static str) {
     }
     assert!(success, "{message}");
 }
+
+include!(concat!(env!("OUT_DIR"), "/sizes.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -796,5 +796,3 @@ fn check_invariant(success: bool, message: &'static str) {
     }
     assert!(success, "{message}");
 }
-
-include!(concat!(env!("OUT_DIR"), "/sizes.rs"));

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::raw::root::RED4ext as red;
+use crate::NativeRepr;
 
 // temporary module, we should split it up into separate files
 
@@ -59,6 +60,15 @@ pub struct MultiChannelCurve<T>([u8; 56], PhantomData<T>);
 pub struct StaticArray<T, const N: usize> {
     entries: [T; N],
     size: u32,
+}
+
+impl<T, const N: usize> From<[T; N]> for StaticArray<T, N> {
+    fn from(entries: [T; N]) -> Self {
+        Self {
+            size: entries.len() as u32,
+            entries,
+        }
+    }
 }
 
 impl<T, const N: usize> StaticArray<T, N> {

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -64,9 +64,23 @@ pub struct StaticArray<T, const N: usize> {
     size: u32,
 }
 
+const fn const_digit_str<const N: usize>() -> &'static str {
+    match N {
+        1 => "1",
+        2 => "2",
+        3 => "3",
+        4 => "4",
+        5 => "5",
+        6 => "6",
+        7 => "7",
+        8 => "8",
+        _ => unimplemented!(),
+    }
+}
+
 unsafe impl<T: NativeRepr, const N: usize> NativeRepr for StaticArray<T, N> {
     const NAME: &'static str = combine!(
-        combine!(combine!("[", crate::const_digit_str(N)), "]"),
+        combine!(combine!("[", const_digit_str::<N>()), "]"),
         T::NAME
     );
 }

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -64,30 +64,11 @@ pub struct StaticArray<T, const N: usize> {
     size: u32,
 }
 
-const fn const_digit_str(x: usize) -> &'static str {
-    match x {
-        1 => "1",
-        2 => "2",
-        3 => "3",
-        4 => "4",
-        5 => "5",
-        6 => "6",
-        7 => "7",
-        8 => "8",
-        9 => "9",
-        10 => "10",
-        11 => "11",
-        12 => "12",
-        13 => "13",
-        14 => "14",
-        15 => "15",
-        16 => "16",
-        _ => unimplemented!(),
-    }
-}
-
 unsafe impl<T: NativeRepr, const N: usize> NativeRepr for StaticArray<T, N> {
-    const NAME: &'static str = combine!(combine!(combine!("[", const_digit_str(N)), "]"), T::NAME);
+    const NAME: &'static str = combine!(
+        combine!(combine!("[", crate::const_digit_str(N)), "]"),
+        T::NAME
+    );
 }
 
 impl<T, const N: usize> From<[T; N]> for StaticArray<T, N> {

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -1,5 +1,7 @@
 use std::marker::PhantomData;
 
+use const_combine::bounded::const_combine as combine;
+
 use crate::raw::root::RED4ext as red;
 use crate::NativeRepr;
 
@@ -60,6 +62,32 @@ pub struct MultiChannelCurve<T>([u8; 56], PhantomData<T>);
 pub struct StaticArray<T, const N: usize> {
     entries: [T; N],
     size: u32,
+}
+
+const fn const_digit_str(x: usize) -> &'static str {
+    match x {
+        1 => "1",
+        2 => "2",
+        3 => "3",
+        4 => "4",
+        5 => "5",
+        6 => "6",
+        7 => "7",
+        8 => "8",
+        9 => "9",
+        10 => "10",
+        11 => "11",
+        12 => "12",
+        13 => "13",
+        14 => "14",
+        15 => "15",
+        16 => "16",
+        _ => unimplemented!(),
+    }
+}
+
+unsafe impl<T: NativeRepr, const N: usize> NativeRepr for StaticArray<T, N> {
+    const NAME: &'static str = combine!(combine!(combine!("[", const_digit_str(N)), "]"), T::NAME);
 }
 
 impl<T, const N: usize> From<[T; N]> for StaticArray<T, N> {


### PR DESCRIPTION
One of my user requested me to expose plugin version as early as possible, so I made a couple of non-breaking changes:
- ~~add different constructors for `alpha`, `beta` and `rc`~~
- ~~add `impl Display for Semver` to be able to return it conveniently as a string~~

I know semver can be a wide topic / opinionated but I had to settle down on a naming convention, so I tried to be as standard as possible.

*update: see my comment below, I simplified its implementation.*