### PR TITLE
Shared pointer

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@ pub use tweak_db_id::TweakDbId;
 pub mod array;
 pub use array::RedArray;
 mod refs;
-pub use refs::{Ref, ScriptRef, WeakRef};
+pub use refs::{Ref, ScriptRef, SharedPtr, WeakRef};
 mod string;
 pub use string::RedString;
 mod cname;

--- a/src/types/allocator.rs
+++ b/src/types/allocator.rs
@@ -4,6 +4,7 @@ use std::{mem, ops, ptr};
 use once_cell::race::OnceNonZeroUsize;
 use sealed::sealed;
 
+use super::refs::RefCount;
 use super::{GlobalFunction, IScriptable, Method, Property, StaticMethod};
 use crate::raw::root::RED4ext as red;
 use crate::raw::root::RED4ext::Memory::AllocationResult;
@@ -113,6 +114,11 @@ impl Poolable for IScriptable {
 }
 
 #[sealed]
+impl Poolable for RefCount {
+    type Pool = RefCountPool;
+}
+
+#[sealed]
 impl<T> Poolable for mem::MaybeUninit<T>
 where
     T: Poolable,
@@ -207,6 +213,15 @@ pub struct ScriptPool;
 #[sealed]
 impl Pool for ScriptPool {
     const NAME: &'static str = "PoolScript";
+}
+
+/// A pool for reference counters.
+#[derive(Debug)]
+pub struct RefCountPool;
+
+#[sealed]
+impl Pool for RefCountPool {
+    const NAME: &'static str = "PoolRefCount";
 }
 
 #[cold]

--- a/src/types/allocator.rs
+++ b/src/types/allocator.rs
@@ -221,7 +221,7 @@ pub struct RefCountPool;
 
 #[sealed]
 impl Pool for RefCountPool {
-    const NAME: &'static str = "PoolRefCount";
+    const NAME: &'static str = "RefCountAllocator";
 }
 
 #[cold]

--- a/src/types/allocator.rs
+++ b/src/types/allocator.rs
@@ -221,7 +221,7 @@ pub struct RefCountPool;
 
 #[sealed]
 impl Pool for RefCountPool {
-    const NAME: &'static str = "RefCountAllocator";
+    const NAME: &'static str = "PoolRefCount";
 }
 
 #[cold]

--- a/src/types/allocator.rs
+++ b/src/types/allocator.rs
@@ -47,7 +47,7 @@ impl IAllocator {
 
 /// A reference to a value stored in a pool.
 #[derive(Debug)]
-pub struct PoolRef<T: Poolable>(*mut T);
+pub struct PoolRef<T: Poolable>(pub(super) *mut T);
 
 impl<T: Poolable> PoolRef<mem::MaybeUninit<T>> {
     #[inline]

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::{mem, ptr};
 
 use super::{CName, ISerializable, PoolRef, Type};
@@ -273,13 +273,13 @@ pub(crate) struct RefCount(red::RefCnt);
 
 impl RefCount {
     #[inline]
-    fn strong(&self) -> &AtomicI32 {
-        unsafe { AtomicI32::from_ptr(&self.0.strongRefs as *const _ as _) }
+    fn strong(&self) -> &AtomicU32 {
+        unsafe { AtomicU32::from_ptr(&self.0.strongRefs as *const _ as _) }
     }
 
     #[inline]
-    fn weak_refs(&self) -> &AtomicI32 {
-        unsafe { AtomicI32::from_ptr(&self.0.weakRefs as *const _ as _) }
+    fn weak_refs(&self) -> &AtomicU32 {
+        unsafe { AtomicU32::from_ptr(&self.0.weakRefs as *const _ as _) }
     }
 
     fn new() -> PoolRef<Self> {

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -346,7 +346,7 @@ impl<T: Default + NativeRepr> SharedPtr<T> {
     pub fn new_with(mut value: T) -> Self {
         let mut this = red::SharedPtrBase::<T>::default();
         let mut refcount = RefCount::new();
-        this.refCount = &mut *refcount as *const _ as *mut _;
+        this.refCount = &mut refcount as *const _ as *mut _;
         this.instance = &mut value as *const _ as *mut _;
         mem::forget(refcount);
         mem::forget(value);

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -344,13 +344,12 @@ impl<T: NativeRepr> Clone for SharedPtr<T> {
 
 impl<T: Default + NativeRepr> SharedPtr<T> {
     #[must_use]
-    pub fn new_with(mut value: T) -> Self {
+    pub fn new_with(value: T) -> Self {
         let mut this = red::SharedPtrBase::<T>::default();
         let refcount = RefCount::new();
         this.refCount = refcount.0 as *mut red::RefCnt;
-        this.instance = &mut value as *const _ as *mut _;
+        this.instance = Box::leak(Box::new(value)) as *const _ as *mut _;
         mem::forget(refcount);
-        mem::forget(value);
         Self(this)
     }
 }

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -2,11 +2,12 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::{mem, ptr};
 
-use super::{CName, ISerializable, Type};
+use super::{CName, ISerializable, PoolRef, Type};
 use crate::class::{NativeType, ScriptClass};
 use crate::raw::root::RED4ext as red;
 use crate::repr::NativeRepr;
 use crate::systems::RttiSystem;
+use crate::types::PoolableOps;
 use crate::{ClassKind, VoidPtr};
 
 /// A reference counted shared pointer to a script class.
@@ -268,7 +269,7 @@ impl<T> Clone for BaseRef<T> {
 
 #[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
-struct RefCount(red::RefCnt);
+pub(crate) struct RefCount(red::RefCnt);
 
 impl RefCount {
     #[inline]
@@ -279,6 +280,16 @@ impl RefCount {
     #[inline]
     fn weak_refs(&self) -> &AtomicU32 {
         unsafe { AtomicU32::from_ptr(&self.0.weakRefs as *const _ as _) }
+    }
+
+    fn new() -> PoolRef<Self> {
+        let mut refcount = RefCount::alloc().expect("should allocate a RefCount");
+        let ptr = refcount.as_mut_ptr();
+        unsafe {
+            (*ptr).0.strongRefs = 1;
+            (*ptr).0.weakRefs = 1;
+            refcount.assume_init()
+        }
     }
 }
 
@@ -316,5 +327,65 @@ impl<'a, T: NativeRepr> ScriptRef<'a, T> {
     #[inline]
     pub fn is_defined(&self) -> bool {
         !self.0.ref_.is_null()
+    }
+}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct SharedPtr<T>(red::SharedPtrBase<T>);
+
+impl<T: NativeRepr> Clone for SharedPtr<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        self.inc_strong();
+        unsafe { ptr::read(self) }
+    }
+}
+
+impl<T: Default + NativeRepr> SharedPtr<T> {
+    pub fn new_with(mut value: T) -> Self {
+        let mut this = red::SharedPtrBase::<T>::default();
+        let mut refcount = RefCount::new();
+        this.refCount = &mut *refcount as *const _ as *mut _;
+        this.instance = &mut value as *const _ as *mut _;
+        mem::forget(refcount);
+        mem::forget(value);
+        Self(this)
+    }
+}
+
+impl<T> SharedPtr<T> {
+    #[inline]
+    fn ref_count(&self) -> Option<&RefCount> {
+        unsafe { self.0.refCount.cast::<RefCount>().as_ref() }
+    }
+
+    #[inline]
+    fn inc_strong(&self) {
+        if let Some(cnt) = self.ref_count() {
+            cnt.strong().fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn dec_strong(&mut self) -> bool {
+        let Some(cnt) = self.ref_count() else {
+            return false;
+        };
+
+        cnt.strong().fetch_sub(1, Ordering::Relaxed) == 1
+    }
+}
+
+impl<T> Drop for SharedPtr<T> {
+    fn drop(&mut self) {
+        if self.dec_strong() && !self.0.instance.is_null() {
+            let own_refcount =
+                unsafe { mem::transmute::<*mut red::RefCnt, PoolRef<RefCount>>(self.0.refCount) };
+            let ptr_instance = self.0.instance;
+            mem::drop(own_refcount);
+            unsafe {
+                ptr::drop_in_place(ptr_instance);
+            }
+        }
     }
 }

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::{mem, ptr};
 
 use super::{CName, ISerializable, PoolRef, Type};
@@ -273,13 +273,13 @@ pub(crate) struct RefCount(red::RefCnt);
 
 impl RefCount {
     #[inline]
-    fn strong(&self) -> &AtomicU32 {
-        unsafe { AtomicU32::from_ptr(&self.0.strongRefs as *const _ as _) }
+    fn strong(&self) -> &AtomicI32 {
+        unsafe { AtomicI32::from_ptr(&self.0.strongRefs as *const _ as _) }
     }
 
     #[inline]
-    fn weak_refs(&self) -> &AtomicU32 {
-        unsafe { AtomicU32::from_ptr(&self.0.weakRefs as *const _ as _) }
+    fn weak_refs(&self) -> &AtomicI32 {
+        unsafe { AtomicI32::from_ptr(&self.0.weakRefs as *const _ as _) }
     }
 
     fn new() -> PoolRef<Self> {

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -346,8 +346,8 @@ impl<T: Default + NativeRepr> SharedPtr<T> {
     #[must_use]
     pub fn new_with(mut value: T) -> Self {
         let mut this = red::SharedPtrBase::<T>::default();
-        let mut refcount = RefCount::new();
-        this.refCount = &mut refcount as *const _ as *mut _;
+        let refcount = RefCount::new();
+        this.refCount = refcount.0 as *mut red::RefCnt;
         this.instance = &mut value as *const _ as *mut _;
         mem::forget(refcount);
         mem::forget(value);

--- a/src/types/refs.rs
+++ b/src/types/refs.rs
@@ -343,6 +343,7 @@ impl<T: NativeRepr> Clone for SharedPtr<T> {
 }
 
 impl<T: Default + NativeRepr> SharedPtr<T> {
+    #[must_use]
     pub fn new_with(mut value: T) -> Self {
         let mut this = red::SharedPtrBase::<T>::default();
         let mut refcount = RefCount::new();


### PR DESCRIPTION
Add basic and _leaky_ support for `red::SharedPtr` to allow working with internal structs.
Safety must be audited first.