### PR TITLE
Fix unused return value

### DIFF
--- a/src/invocable.rs
+++ b/src/invocable.rs
@@ -101,7 +101,9 @@ macro_rules! impl_global_invocable {
                 fn invoke(self, _ctx: &IScriptable, frame: &mut StackFrame, ret: &mut MaybeUninit<R::Repr>) {
                     $(let $types = unsafe { frame.get_arg::<$types>() };)*
                     let res = self($($types,)*);
-                    unsafe { ret.as_mut_ptr().write(res.into_repr()) }
+                    if !ret.as_mut_ptr().is_null() {
+                        unsafe { ret.as_mut_ptr().write(res.into_repr()) }
+                    }
                 }
             }
         )*
@@ -147,7 +149,9 @@ macro_rules! impl_method_invocable {
                 fn invoke(self, ctx: &Ctx, frame: &mut StackFrame, ret: &mut MaybeUninit<R::Repr>) {
                     $(let $types = unsafe { frame.get_arg::<$types>() };)*
                     let res = self(ctx, $($types,)*);
-                    unsafe { ret.as_mut_ptr().write(res.into_repr()) }
+                    if !ret.as_mut_ptr().is_null() {
+                        unsafe { ret.as_mut_ptr().write(res.into_repr()) }
+                    }
                 }
             }
         )*

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -37,7 +37,7 @@ unsafe impl<A: ScriptClass> NativeRepr for WeakRef<A> {
     const NAME: &'static str = combine!("whandle:", A::NAME);
 }
 
-unsafe impl<'a, A: NativeRepr> NativeRepr for ScriptRef<'a, A> {
+unsafe impl<A: NativeRepr> NativeRepr for ScriptRef<'_, A> {
     const NAME: &'static str = combine!("script_ref:", A::NAME);
 }
 

--- a/src/types/allocator.rs
+++ b/src/types/allocator.rs
@@ -211,7 +211,7 @@ pub(super) unsafe fn vault_alloc(vault: *mut red::Memory::Vault, size: u32) -> O
         );
         alloc(vault, &mut result, size as _);
     };
-    (!result.memory.is_null()).then(|| result.memory)
+    (!result.memory.is_null()).then_some(result.memory)
 }
 
 pub(super) unsafe fn vault_alloc_aligned(
@@ -227,7 +227,7 @@ pub(super) unsafe fn vault_alloc_aligned(
         );
         alloc_aligned(vault, &mut result, size as _, alignment as _);
     };
-    (!result.memory.is_null()).then(|| result.memory)
+    (!result.memory.is_null()).then_some(result.memory)
 }
 
 #[cold]


### PR DESCRIPTION
The crash happens when the function returns a value which is ignored on Redscript side.

For example, having defined this method:
```swift
public native class AudioSystemExt {
	public final native func RegisterEmitter(...) -> Bool;
}
```
Would work fine when used this way:
```swift
let registered = system.RegisterEmitter(...);
```
But would cause a crash when used this way:
```swift
system.RegisterEmitter(...);
```