### PR TITLE
Fix native class allocator

### DIFF
--- a/src/types/allocator.rs
+++ b/src/types/allocator.rs
@@ -245,18 +245,6 @@ impl Pool for ScriptPool {
     const NAME: &'static str = "PoolScript";
 }
 
-pub(super) unsafe fn vault_alloc(vault: *mut red::Memory::Vault, size: u32) -> Option<VoidPtr> {
-    let mut result = AllocationResult::default();
-    unsafe {
-        let alloc = crate::fn_from_hash!(
-            Memory_Vault_Alloc,
-            unsafe extern "C" fn(*mut red::Memory::Vault, *mut AllocationResult, u32)
-        );
-        alloc(vault, &mut result, size as _);
-    };
-    (!result.memory.is_null()).then_some(result.memory)
-}
-
 pub(super) unsafe fn vault_alloc_aligned(
     vault: *mut red::Memory::Vault,
     size: u32,

--- a/src/types/hash.rs
+++ b/src/types/hash.rs
@@ -1,7 +1,8 @@
 use std::iter::FusedIterator;
 use std::{mem, ptr, slice};
 
-use super::{CName, IAllocator};
+use super::allocator::ICollectionAllocator;
+use super::CName;
 use crate::raw::root::RED4ext as red;
 
 const INVALID_INDEX: u32 = u32::MAX;
@@ -215,8 +216,8 @@ impl<K, V> RedHashMap<K, V> {
     }
 
     #[inline]
-    fn allocator(&self) -> &IAllocator {
-        unsafe { &*(&self.0.allocator as *const _ as *const IAllocator) }
+    fn allocator(&self) -> &ICollectionAllocator {
+        unsafe { &*(&self.0.allocator as *const _ as *const ICollectionAllocator) }
     }
 }
 


### PR DESCRIPTION
This one is more obscure and I didn't quite understand it, but basically what happened after the fix for the `RedHashMap` is that the native class export was somehow broken. So I split `IAllocator` reverting the code as it was, while adding `ICollectionAllocator` to keep the fix for `RedHashMap`.