### PR TITLE
EntityId display

### DIFF
--- a/src/types/entity_id.rs
+++ b/src/types/entity_id.rs
@@ -102,3 +102,29 @@ impl fmt::Debug for EntityId {
             .finish_non_exhaustive()
     }
 }
+
+impl std::fmt::Display for EntityId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.is_defined(), self.is_persistable()) {
+            (true, persistable) => {
+                write!(
+                    f,
+                    "{} {}",
+                    self.0.hash,
+                    match (persistable, self.is_dynamic(), self.is_transient()) {
+                        (true, true, true) => "(P|D|T)",
+                        (true, true, false) => "(P|D)",
+                        (true, false, true) => "(P|S|T)",
+                        (true, false, false) => "(P|S)",
+                        (false, true, true) => "(D|T)",
+                        (false, true, false) => "(D)",
+                        (false, false, true) => "(S|T)",
+                        (false, false, false) => "(S)",
+                    }
+                )
+            }
+            (false, false) => write!(f, "undefined"),
+            (false, true) => write!(f, "undefined (P)"),
+        }
+    }
+}

--- a/src/types/entity_id.rs
+++ b/src/types/entity_id.rs
@@ -103,6 +103,13 @@ impl fmt::Debug for EntityId {
     }
 }
 
+/// A simple entity ID representation.
+///
+/// Flags are displayed as:
+/// - `P`ersistable
+/// - `D`ynamic
+/// - `T`ransient
+/// - `S`tatic
 impl std::fmt::Display for EntityId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.is_defined(), self.is_persistable()) {


### PR DESCRIPTION
This one is a QoL improvement when there's dozen of `EntityID` being logged in second(s) in the console, making it way more easier to spot at an eye glance.