### PR TITLE
Use unsafe no_mangle for plugin export functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,13 +151,13 @@ macro_rules! export_plugin_symbols {
         mod __api {
             use super::*;
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[allow(non_snake_case, unused_variables)]
             unsafe extern "C" fn Query(info: *mut $crate::internal::PluginInfo) {
                 *info = <$trait as $crate::PluginOps>::info().into_raw();
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[allow(non_snake_case, unused_variables)]
             extern "C" fn Main(
                 handle: $crate::internal::PluginHandle,
@@ -170,7 +170,7 @@ macro_rules! export_plugin_symbols {
                 }
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[allow(non_snake_case, unused_variables)]
             extern "C" fn Supports() -> u32 {
                 ::std::convert::Into::into(<$trait as $crate::Plugin>::API_VERSION)


### PR DESCRIPTION
New versions of rust disallow the use of no_mangle without the unsafe attribute. This issue was discussed here: https://github.com/rust-lang/rust/issues/28179#issuecomment-2314797945
