### PR TITLE
Expose common traits from underlying representation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,22 +724,21 @@ impl PluginInfo {
     }
 }
 
-const fn fnv1a64(str: &[u8]) -> u64 {
-    const PRIME: u64 = 0x0100_0000_01b3;
+const fn fnv1a64(bytes: &[u8]) -> u64 {
     const SEED: u64 = 0xCBF2_9CE4_8422_2325;
 
-    let mut tail = str;
+    let mut tail = bytes;
     let mut hash = SEED;
-    loop {
-        match tail.split_first() {
-            Some((head, rem)) => {
-                hash ^= *head as u64;
-                hash = hash.wrapping_mul(PRIME);
-                tail = rem;
-            }
-            None => break hash,
-        }
+    while let [head, rem @ ..] = tail {
+        tail = rem;
+        hash = fnv1a64_step(hash, *head);
     }
+    hash
+}
+
+const fn fnv1a64_step(hash: u64, byte: u8) -> u64 {
+    const PRIME: u64 = 0x0100_0000_01b3;
+    (hash ^ byte as u64).wrapping_mul(PRIME)
 }
 
 const fn fnv1a32(str: &str) -> u32 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,6 +10,8 @@ mod game_time;
 pub use game_time::GameTime;
 mod item_id;
 pub use item_id::{GameEItemIdFlag, GamedataItemStructure, ItemId};
+mod node_ref;
+pub use node_ref::*;
 mod res;
 pub use res::{RaRef, ResRef};
 mod tweak_db_id;
@@ -47,6 +49,5 @@ pub use game_engine::{GameEngine, GameInstance, NativeGameInstance, ScriptableSy
 mod misc;
 pub use misc::{
     Curve, DataBuffer, DateTime, DeferredDataBuffer, EditorObjectId, Guid, LocalizationString,
-    MessageResourcePath, MultiChannelCurve, NodeRef, ResourceRef, SharedDataBuffer, StaticArray,
-    Variant,
+    MessageResourcePath, MultiChannelCurve, ResourceRef, SharedDataBuffer, StaticArray, Variant,
 };

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -14,6 +14,10 @@ pub struct LocalizationString(red::LocalizationString);
 #[repr(transparent)]
 pub struct NodeRef(red::NodeRef);
 
+unsafe impl NativeRepr for NodeRef {
+    const NAME: &'static str = "worldGlobalNodeRef";
+}
+
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct DataBuffer(red::DataBuffer);

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -10,7 +10,7 @@ use crate::raw::root::RED4ext as red;
 #[repr(transparent)]
 pub struct LocalizationString(red::LocalizationString);
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(transparent)]
 pub struct NodeRef(red::NodeRef);
 
@@ -22,7 +22,7 @@ pub struct DataBuffer(red::DataBuffer);
 #[repr(transparent)]
 pub struct DeferredDataBuffer(red::DeferredDataBuffer);
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(transparent)]
 pub struct SharedDataBuffer(red::SharedDataBuffer);
 
@@ -34,7 +34,7 @@ pub struct DateTime(red::CDateTime);
 #[repr(transparent)]
 pub struct Guid(red::CGUID);
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(transparent)]
 pub struct EditorObjectId(red::EditorObjectID);
 

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -10,14 +10,6 @@ use crate::raw::root::RED4ext as red;
 #[repr(transparent)]
 pub struct LocalizationString(red::LocalizationString);
 
-#[derive(Debug, Default, Clone, Copy)]
-#[repr(transparent)]
-pub struct NodeRef(red::NodeRef);
-
-unsafe impl NativeRepr for NodeRef {
-    const NAME: &'static str = "worldGlobalNodeRef";
-}
-
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct DataBuffer(red::DataBuffer);

--- a/src/types/node_ref.rs
+++ b/src/types/node_ref.rs
@@ -73,7 +73,7 @@ impl From<NodeRef> for u64 {
     }
 }
 
-fn fnv1a(name: &[u8]) -> u64 {
+const fn fnv1a(name: &[u8]) -> u64 {
     const PRIME: u64 = 0x100000001b3;
     const SEED: u64 = 0xCBF29CE484222325;
 

--- a/src/types/node_ref.rs
+++ b/src/types/node_ref.rs
@@ -25,7 +25,7 @@ impl NodeRef {
         let mut i = 0;
 
         while i < name.len() {
-            let b = name[i];
+            let mut b = name[i];
 
             if b == b'#' {
                 i += 1;
@@ -41,6 +41,8 @@ impl NodeRef {
                 if i >= name.len() {
                     break;
                 }
+
+                b = name[i];
             }
 
             hash ^= b as u64;

--- a/src/types/node_ref.rs
+++ b/src/types/node_ref.rs
@@ -73,7 +73,7 @@ impl From<NodeRef> for u64 {
     }
 }
 
-fn fnv1a(name: &[u8]) -> Self {
+fn fnv1a(name: &[u8]) -> u64 {
     const PRIME: u64 = 0x100000001b3;
     const SEED: u64 = 0xCBF29CE484222325;
 

--- a/src/types/node_ref.rs
+++ b/src/types/node_ref.rs
@@ -1,7 +1,9 @@
+use std::hash::Hash;
+
 use crate::NativeRepr;
 use crate::raw::root::RED4ext as red;
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
 pub struct NodeRef(red::NodeRef);
 
@@ -49,6 +51,38 @@ impl NodeRef {
         Self(red::NodeRef {
             hash: if hash == SEED { 0 } else { hash },
         })
+    }
+}
+
+impl PartialEq for NodeRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.hash == other.0.hash
+    }
+}
+
+impl Eq for NodeRef {}
+
+impl PartialOrd for NodeRef {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NodeRef {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.hash.cmp(&other.0.hash)
+    }
+}
+
+impl Hash for NodeRef {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash.hash(state);
+    }
+}
+
+impl Default for NodeRef {
+    fn default() -> Self {
+        Self(red::NodeRef { hash: 0 })
     }
 }
 

--- a/src/types/node_ref.rs
+++ b/src/types/node_ref.rs
@@ -17,6 +17,13 @@ impl NodeRef {
         self.0.hash != 0
     }
 
+    /// Creates a new `NodeRef` from the given string.
+    /// This function just calculates the hash of the string using the FNV-1a algorithm.
+    #[inline]
+    pub const fn new(name: &str) -> Self {
+        Self::from_bytes(name.as_bytes())
+    }
+
     pub const fn from_bytes(name: &[u8]) -> Self {
         const PRIME: u64 = 0x100000001b3;
         const SEED: u64 = 0xCBF29CE484222325;
@@ -109,32 +116,45 @@ mod test {
         // base\quest\minor_quests\mq049\scenes\mq049_braindance.scene
         // root.props[0].findEntityInNodeParams
         assert_eq!(
-            u64::from(NodeRef::from_bytes("#mq049_braindance_player".as_bytes())),
+            u64::from(NodeRef::new("#mq049_braindance_player")),
             11_169_148_225_646_932_588
         );
         // base\worlds\03_night_city\_compiled\default\exterior_-56_-66_1_0.streamingsector
         // root.nodeRefs[7]
         assert_eq!(
-            u64::from(NodeRef::from_bytes(
-                "$/03_night_city/c_westbrook/charter_hill/hil_ce_prefabU4INIHQ/ce_wbr_hil_06_prefabOLAKG7I/ce_wbr_hil_06_env_prefabCSSG5EI/#ce_wbr_hil_06_decoration/decoset_pallet_stack_v4_prefabTWZWJMQ/coverObject_004".as_bytes()
+            u64::from(NodeRef::new(
+                "$/03_night_city/c_westbrook/charter_hill/hil_ce_prefabU4INIHQ/ce_wbr_hil_06_prefabOLAKG7I/ce_wbr_hil_06_env_prefabCSSG5EI/#ce_wbr_hil_06_decoration/decoset_pallet_stack_v4_prefabTWZWJMQ/coverObject_004"
             )),
             1_991_599_692_993_048_849
         );
         // base\worlds\03_night_city\_compiled\default\exterior_-56_-66_1_0.streamingsector
         // root.nodeRefs[0]
         assert_eq!(
-            u64::from(NodeRef::from_bytes(
-                "$/03_night_city/sw1/sw1_env_prefabBCIH5UQ/sw1_architecture_prefabOZJAM6I/exterior_prefabAMKHYOI/arroyo_building_v20_001_prefabM3O3CRQ/decorative_single_door_prefabTIYIITI/{single_door}_prefabPPPD5FQ".as_bytes()
+            u64::from(NodeRef::new(
+                "$/03_night_city/sw1/sw1_env_prefabBCIH5UQ/sw1_architecture_prefabOZJAM6I/exterior_prefabAMKHYOI/arroyo_building_v20_001_prefabM3O3CRQ/decorative_single_door_prefabTIYIITI/{single_door}_prefabPPPD5FQ"
             )),
             3_692_047_525_447_499_933
         );
         // base\worlds\03_night_city\_compiled\default\interior_-9_-47_0_0.streamingsector
         // root.nodeRefs[2]
         assert_eq!(
-            u64::from(NodeRef::from_bytes(
-                "$/03_night_city/#c_santo_domingo/arroyo/loc_q112_arasaka_industrial_park_warehouse_prefab5EDXBRA/loc_q112_arasaka_industrial_park_warehouse_env_prefab6E43DLA/loc_q112_warehouse_underground_prefabZG2YPFA/loc_q112_warehouse_underground_int_prefab2WZF5RY/loc_q112_warehouse_underground_int_decor_prefabAFW34IY/EntityNode_prefabXTLDHPI".as_bytes()
+            u64::from(NodeRef::new(
+                "$/03_night_city/#c_santo_domingo/arroyo/loc_q112_arasaka_industrial_park_warehouse_prefab5EDXBRA/loc_q112_arasaka_industrial_park_warehouse_env_prefab6E43DLA/loc_q112_warehouse_underground_prefabZG2YPFA/loc_q112_warehouse_underground_int_prefab2WZF5RY/loc_q112_warehouse_underground_int_decor_prefabAFW34IY/EntityNode_prefabXTLDHPI"
             )),
             9_372_795_654_866_159_000
+        );
+        // example from Discord
+        assert_eq!(
+            u64::from(NodeRef::new(
+                "$/03_night_city/part_a;#alias_a/part_b;#alias_b"
+            )),
+            3_039_318_882_151_703_375
+        );
+        assert_eq!(
+            u64::from(NodeRef::new(
+                "$/03_night_city/part_a;#alias_a/part_b;#alias_b"
+            )),
+            u64::from(NodeRef::new("$/03_night_city/part_a/part_b"))
         );
     }
 }

--- a/src/types/node_ref.rs
+++ b/src/types/node_ref.rs
@@ -1,0 +1,104 @@
+use crate::NativeRepr;
+use crate::raw::root::RED4ext as red;
+
+#[derive(Debug, Default, Clone, Copy)]
+#[repr(transparent)]
+pub struct NodeRef(red::NodeRef);
+
+unsafe impl NativeRepr for NodeRef {
+    const NAME: &'static str = "worldGlobalNodeRef";
+}
+
+impl NodeRef {
+    #[inline]
+    pub const fn is_defined(self) -> bool {
+        self.0.hash != 0
+    }
+
+    pub const fn from_bytes(name: &[u8]) -> Self {
+        const PRIME: u64 = 0x100000001b3;
+        const SEED: u64 = 0xCBF29CE484222325;
+
+        let mut hash: u64 = SEED;
+        let mut i = 0;
+
+        while i < name.len() {
+            let b = name[i];
+
+            if b == b'#' {
+                i += 1;
+                continue;
+            }
+
+            if b == b';' {
+                i += 1;
+                while i < name.len() && name[i] != b'/' {
+                    i += 1;
+                }
+
+                if i >= name.len() {
+                    break;
+                }
+            }
+
+            hash ^= b as u64;
+            hash = hash.wrapping_mul(PRIME);
+            i += 1;
+        }
+
+        Self(red::NodeRef {
+            hash: if hash == SEED { 0 } else { hash },
+        })
+    }
+}
+
+impl From<u64> for NodeRef {
+    fn from(hash: u64) -> Self {
+        Self(red::NodeRef { hash })
+    }
+}
+
+impl From<NodeRef> for u64 {
+    fn from(NodeRef(red::NodeRef { hash }): NodeRef) -> Self {
+        hash
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn calculate_hashes() {
+        // base\quest\minor_quests\mq049\scenes\mq049_braindance.scene
+        // root.props[0].findEntityInNodeParams
+        assert_eq!(
+            u64::from(NodeRef::from_bytes("#mq049_braindance_player".as_bytes())),
+            11_169_148_225_646_932_588
+        );
+        // base\worlds\03_night_city\_compiled\default\exterior_-56_-66_1_0.streamingsector
+        // root.nodeRefs[7]
+        assert_eq!(
+            u64::from(NodeRef::from_bytes(
+                "$/03_night_city/c_westbrook/charter_hill/hil_ce_prefabU4INIHQ/ce_wbr_hil_06_prefabOLAKG7I/ce_wbr_hil_06_env_prefabCSSG5EI/#ce_wbr_hil_06_decoration/decoset_pallet_stack_v4_prefabTWZWJMQ/coverObject_004".as_bytes()
+            )),
+            1_991_599_692_993_048_849
+        );
+        // base\worlds\03_night_city\_compiled\default\exterior_-56_-66_1_0.streamingsector
+        // root.nodeRefs[0]
+        assert_eq!(
+            u64::from(NodeRef::from_bytes(
+                "$/03_night_city/sw1/sw1_env_prefabBCIH5UQ/sw1_architecture_prefabOZJAM6I/exterior_prefabAMKHYOI/arroyo_building_v20_001_prefabM3O3CRQ/decorative_single_door_prefabTIYIITI/{single_door}_prefabPPPD5FQ".as_bytes()
+            )),
+            3_692_047_525_447_499_933
+        );
+        // base\worlds\03_night_city\_compiled\default\interior_-9_-47_0_0.streamingsector
+        // root.nodeRefs[2]
+        assert_eq!(
+            u64::from(NodeRef::from_bytes(
+                "$/03_night_city/#c_santo_domingo/arroyo/loc_q112_arasaka_industrial_park_warehouse_prefab5EDXBRA/loc_q112_arasaka_industrial_park_warehouse_env_prefab6E43DLA/loc_q112_warehouse_underground_prefabZG2YPFA/loc_q112_warehouse_underground_int_prefab2WZF5RY/loc_q112_warehouse_underground_int_decor_prefabAFW34IY/EntityNode_prefabXTLDHPI".as_bytes()
+            )),
+            9_372_795_654_866_159_000
+        );
+    }
+}


### PR DESCRIPTION
Expose traits declared on underlying native types, useful in many cases and required for e.g. `StackFrame::get_arg`.

> [!NOTE]  
> This PR requires #74 to gets merged for tests to pass.