### PR TITLE
Increase FnPtr args count

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,9 +581,11 @@ macro_rules! hooks {
             static mut DETOUR: Option<unsafe extern "C" fn($($arg: $ty),*, cb: unsafe extern "C" fn($($arg: $ty),*) -> $ret) -> $ret> = None;
 
             unsafe extern "C" fn internal($($arg: $ty),*) -> $ret {
-                let target = unsafe { TARGET.expect("target function should be set") };
-                let detour = unsafe { DETOUR.expect("detour function should be set") };
-                detour($($arg,)* target)
+                unsafe {
+                    let target = TARGET.expect("target function should be set");
+                    let detour = DETOUR.expect("detour function should be set");
+                    detour($($arg,)* target)
+                }
             }
 
             static mut HOOK: $crate::Hook<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,6 +639,8 @@ impl_fn_ptr!(A, B, C, D, E);
 impl_fn_ptr!(A, B, C, D, E, F);
 impl_fn_ptr!(A, B, C, D, E, F, G);
 impl_fn_ptr!(A, B, C, D, E, F, G, H);
+impl_fn_ptr!(A, B, C, D, E, F, G, H, I);
+impl_fn_ptr!(A, B, C, D, E, F, G, H, I, J);
 
 /// A callback function to be called when a state is entered, updated, or exited.
 pub type StateHandler = unsafe extern "C" fn(app: &GameApp);


### PR DESCRIPTION
Increase to `10` args for `FnPtr` trait.
This is necessary for some subroutines like this in particular, which i'm gonna need for dialog support in audioware.
<img width="386" height="237" alt="Screenshot 2025-08-30 211712" src="https://github.com/user-attachments/assets/1e10f310-8e5a-4598-ba1a-ec79da50f837" />
I also fixed a clippy warning for [unsafe_op_in_unsafe_fn](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html), and bumped RED4ext.SDK submodule commit SHA.