### PR TITLE
Support plugin unload

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,11 +82,11 @@ pub trait Plugin {
     }
 
     /// A function that is called when the plugin is loaded.
-    /// 
+    ///
     /// For more informations, see [game's lifecycle](https://docs.red4ext.com/mod-developers/custom-game-states#games-life-cycle).
     fn on_load(_env: &SdkEnv) {}
     /// A function that is called when the plugin is unloaded.
-    /// 
+    ///
     /// For more informations, see [game's lifecycle](https://docs.red4ext.com/mod-developers/custom-game-states#games-life-cycle).
     fn on_unload(_env: &SdkEnv) {}
 }
@@ -684,7 +684,7 @@ pub struct GameApp(red::CGameApplication);
 /// A listener for state changes in the game application.
 /// The listener can be attached to a specific state type using the [`SdkEnv::add_listener`]
 /// method.
-/// 
+///
 /// For more informations, see [game's lifecycle](https://docs.red4ext.com/mod-developers/custom-game-states#games-life-cycle).
 #[derive(Debug, Default)]
 #[repr(transparent)]
@@ -693,7 +693,7 @@ pub struct StateListener(red::GameState);
 #[allow(clippy::missing_transmute_annotations)]
 impl StateListener {
     /// Sets a callback to be called when the state is entered.
-    /// 
+    ///
     /// Called immediately after the state is activated.
     /// This function is called once by the game, so be careful what you want to do here.
     #[inline]
@@ -705,7 +705,7 @@ impl StateListener {
     }
 
     /// Sets a callback to be called when the state is updated.
-    /// 
+    ///
     /// Called every frame. This function can contain more complex code.
     #[inline]
     pub fn with_on_update(self, cb: StateHandler) -> Self {
@@ -716,7 +716,7 @@ impl StateListener {
     }
 
     /// Sets a callback to be called when the state is exited.
-    /// 
+    ///
     /// Called when the state is ending.
     /// This function is called once by the game, so be careful what you want to do here.
     #[inline]


### PR DESCRIPTION
As [suggested by wopss](https://discord.com/channels/717692382849663036/839400251680227339/1464280548133572691), this PR exposes `on_exit` method to `PluginOps` called on `EMainReason::Unload` for plugin resources cleaning purpose.
> Related to this [incoming upstream fix on RED4ext](https://github.com/wopss/RED4ext/pull/120) and #82.

Edit: fixes https://github.com/jac3km4/red4ext-rs/issues/82