### PR TITLE
Allow support for native game systems

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -45,7 +45,10 @@ pub use hash::{Hash, RedHashMap};
 mod sync;
 pub use sync::{RwSpinLockReadGuard, RwSpinLockWriteGuard};
 mod game_engine;
-pub use game_engine::{GameEngine, GameInstance, NativeGameInstance, ScriptableSystem};
+pub use game_engine::{
+    GameEngine, GameInstance, IGameSystem, IGameSystemVft, IUpdatableSystem, IUpdatableSystemVft,
+    NativeGameInstance, ScriptableSystem,
+};
 mod misc;
 pub use misc::{
     Curve, DataBuffer, DateTime, DeferredDataBuffer, EditorObjectId, Guid, LocalizationString,

--- a/src/types/game_engine.rs
+++ b/src/types/game_engine.rs
@@ -120,7 +120,7 @@ unsafe impl ScriptClass for IUpdatableSystem {
 impl IUpdatableSystem {
     #[inline]
     pub fn vft(&self) -> &IUpdatableSystemVft {
-        unsafe { &*(mem::transmute::<&IScriptableVft, &IUpdatableSystemVft>(self.0.vft())) }
+        unsafe { mem::transmute::<&IScriptableVft, &IUpdatableSystemVft>(self.0.vft()) }
     }
 }
 
@@ -145,7 +145,7 @@ unsafe impl ScriptClass for IGameSystem {
 impl IGameSystem {
     #[inline]
     pub fn vft(&self) -> &IGameSystemVft {
-        unsafe { &*(mem::transmute::<&IUpdatableSystemVft, &IGameSystemVft>(self.base.vft())) }
+        unsafe { mem::transmute::<&IUpdatableSystemVft, &IGameSystemVft>(self.base.vft()) }
     }
 }
 

--- a/src/types/game_engine.rs
+++ b/src/types/game_engine.rs
@@ -4,6 +4,7 @@ use super::{IScriptable, Ref, Type};
 use crate::class::{ScriptClass, class_kind};
 use crate::raw::root::RED4ext as red;
 use crate::types::WeakRef;
+use crate::types::rtti::IScriptableVft;
 use crate::{NativeRepr, VoidPtr};
 
 /// Scripted game instance.
@@ -105,4 +106,32 @@ impl AsRef<IScriptable> for ScriptableSystem {
     fn as_ref(&self) -> &IScriptable {
         unsafe { mem::transmute(&self.0._base._base) }
     }
+}
+
+#[repr(transparent)]
+pub struct IUpdatableSystem(IScriptable);
+
+unsafe impl ScriptClass for IUpdatableSystem {
+    type Kind = class_kind::Native;
+
+    const NAME: &'static str = "IUpdatableSystem";
+}
+
+impl IUpdatableSystem {
+    #[inline]
+    pub fn vft(&self) -> &IUpdatableSystemVft {
+        unsafe { &*(mem::transmute::<&IScriptableVft, &IUpdatableSystemVft>(self.0.vft())) }
+    }
+}
+
+impl AsRef<IScriptable> for IUpdatableSystem {
+    fn as_ref(&self) -> &IScriptable {
+        unsafe { mem::transmute(&self.0) }
+    }
+}
+
+#[repr(C)]
+pub struct IUpdatableSystemVft {
+    base: IScriptableVft,
+    on_register_updates: unsafe extern "C" fn(this: VoidPtr, registrar: VoidPtr),
 }

--- a/src/types/game_engine.rs
+++ b/src/types/game_engine.rs
@@ -131,7 +131,57 @@ impl AsRef<IScriptable> for IUpdatableSystem {
 }
 
 #[repr(C)]
+pub struct IGameSystem {
+    base: IUpdatableSystem,
+    game_instance: *mut NativeGameInstance,
+}
+
+unsafe impl ScriptClass for IGameSystem {
+    type Kind = class_kind::Native;
+
+    const NAME: &'static str = "gameIGameSystem";
+}
+
+impl IGameSystem {
+    #[inline]
+    pub fn vft(&self) -> &IGameSystemVft {
+        unsafe { &*(mem::transmute::<&IUpdatableSystemVft, &IGameSystemVft>(self.base.vft())) }
+    }
+}
+
+impl AsRef<IScriptable> for IGameSystem {
+    fn as_ref(&self) -> &IScriptable {
+        unsafe { mem::transmute(&self.base.0) }
+    }
+}
+
+#[repr(C)]
 pub struct IUpdatableSystemVft {
     base: IScriptableVft,
     on_register_updates: unsafe extern "C" fn(this: VoidPtr, registrar: VoidPtr),
+}
+
+#[repr(C)]
+pub struct IGameSystemVft {
+    base: IUpdatableSystemVft,
+    on_world_attached: VoidPtr,
+    on_before_world_detach: VoidPtr,
+    on_world_detached: VoidPtr,
+    on_after_world_detach: VoidPtr,
+    on_before_game_save: VoidPtr,
+    on_game_save: VoidPtr,
+    on_after_game_save: VoidPtr,
+    on_game_load: VoidPtr,
+    on_game_restored: VoidPtr,
+    on_game_prepared: VoidPtr,
+    on_game_paused: VoidPtr,
+    on_game_resumed: VoidPtr,
+    is_saving_locked: VoidPtr,
+    on_streaming_world_loaded: VoidPtr,
+    sub_180: VoidPtr,
+    sub_188: VoidPtr,
+    sub_190: VoidPtr,
+    sub_198: VoidPtr,
+    on_initialize: VoidPtr,
+    on_uninitialize: VoidPtr,
 }

--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -1448,6 +1448,11 @@ impl ISerializable {
             .clone()
         })
     }
+
+    #[inline]
+    pub fn vft(&self) -> &ISerializableVft {
+        unsafe { &*(self.0.vtable_ as *const ISerializableVft) }
+    }
 }
 
 impl PtrEq for ISerializable {
@@ -1594,3 +1599,34 @@ struct FunctionVft {
     destruct: unsafe extern "C" fn(this: &mut Function),
     get_parent: unsafe extern "C" fn(this: &Function) -> *mut Class,
 }
+#[repr(C)]
+pub struct ISerializableVft {
+    get_native_type: unsafe extern "C" fn(this: &ISerializable) -> *mut Class,
+    get_type: unsafe extern "C" fn(this: &ISerializable) -> *mut Class,
+    get_allocator: unsafe extern "C" fn(this: &ISerializable) -> *mut IAllocator,
+    destroy: unsafe extern "C" fn(this: *mut ISerializable),
+    sub_20: VoidPtr,
+    post_load: VoidPtr,
+    sub_30: VoidPtr,
+    sub_38: VoidPtr,
+    sub_40: VoidPtr,
+    sub_48: VoidPtr,
+    sub_50: VoidPtr,
+    sub_58: VoidPtr,
+    sub_60: VoidPtr,
+    sub_68: VoidPtr,
+    sub_70: VoidPtr,
+    sub_78: VoidPtr,
+    sub_80: VoidPtr,
+    sub_88: VoidPtr,
+    sub_90: VoidPtr,
+    sub_98: VoidPtr,
+    sub_a0: VoidPtr,
+    sub_a8: VoidPtr,
+    sub_b0: VoidPtr,
+    sub_b8: VoidPtr,
+    sub_c0: VoidPtr,
+    sub_c8: VoidPtr,
+    can_be_destructed: unsafe extern "C" fn(this: VoidPtr) -> bool,
+}
+

--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -1500,6 +1500,11 @@ impl IScriptable {
     pub fn set_native_type(&mut self, class: &Class) {
         self.0.nativeType = class.as_raw() as *const _ as *mut red::CClass;
     }
+
+    #[inline]
+    pub fn vft(&self) -> &IScriptableVft {
+        unsafe { &*(self.0._base.vtable_ as *const IScriptableVft) }
+    }
 }
 
 impl Default for IScriptable {
@@ -1599,6 +1604,7 @@ struct FunctionVft {
     destruct: unsafe extern "C" fn(this: &mut Function),
     get_parent: unsafe extern "C" fn(this: &Function) -> *mut Class,
 }
+
 #[repr(C)]
 pub struct ISerializableVft {
     get_native_type: unsafe extern "C" fn(this: &ISerializable) -> *mut Class,
@@ -1630,3 +1636,13 @@ pub struct ISerializableVft {
     can_be_destructed: unsafe extern "C" fn(this: VoidPtr) -> bool,
 }
 
+#[repr(C)]
+pub struct IScriptableVft {
+    base: ISerializableVft,
+    sub_d8: VoidPtr,
+    sub_e0: VoidPtr,
+    sub_e8: VoidPtr,
+    sub_f0: VoidPtr,
+    sub_f8: VoidPtr,
+    sub_100: VoidPtr,
+}


### PR DESCRIPTION
This PR:
- creates missing
  -  [vft for ISerializable](https://github.com/wopss/RED4ext.SDK/blob/5b6ec8bbac245bf21ec740730acb345bf02f5d04/include/RED4ext/ISerializable.hpp#L30-L56)
  -  [vft for IScriptable](https://github.com/wopss/RED4ext.SDK/blob/5b6ec8bbac245bf21ec740730acb345bf02f5d04/include/RED4ext/Scripting/IScriptable.hpp#L20-L25)
  - [IUpdatableSystem bindings and vft](https://github.com/wopss/RED4ext.SDK/blob/5b6ec8bbac245bf21ec740730acb345bf02f5d04/include/RED4ext/Scripting/Natives/IUpdatableSystem.hpp)
  - [IGameSystem bindings and vft](https://github.com/wopss/RED4ext.SDK/blob/5b6ec8bbac245bf21ec740730acb345bf02f5d04/include/RED4ext/Scripting/Natives/gameIGameSystem.hpp)
- exposes existing and new vft to downstream crates

which are the prerequisites for downstream crates to add support for native game systems.

I realized it when trying to implement [IEntityStubSystem::FindStub](https://github.com/wopss/RED4ext.SDK/blob/5b6ec8bbac245bf21ec740730acb345bf02f5d04/include/RED4ext/Scripting/Natives/gameIEntityStubSystem.hpp#L134) to resolve `CommunityID` from `EntityID`, [in much the same fashion as RedHotTools](https://github.com/psiberx/cp2077-red-hot-tools/blob/5166da4783375b9942a20792c5ceb6c3c1067a53/src/App/World/WorldInspector.cpp#L435-L444).

Exposing `.vft()` then allow to do, e.g.
```rs
// skipping some code for brevity

#[repr(transparent)]
pub struct IEntityStubSystem(red4ext_rs::types::IGameSystem);

unsafe impl ScriptClass for IEntityStubSystem {
    type Kind = Native;
    const NAME: &'static str = "gameIEntityStubSystem";
}

impl IEntityStubSystem {
    #[inline]
    pub fn vft(&self) -> &IEntityStubSystemVft {
        unsafe { &*(std::mem::transmute::<&IGameSystemVft, &IEntityStubSystemVft>(self.0.vft())) }
    }
}

impl IEntityStubSystem {
    fn find_stub(&self, entity_id: EntityId) -> Option<EntityStub> {
        let stub = unsafe { (self.vft().find_stub)(self, entity_id) };
        if stub.is_null() {
            return None;
        }
        Some(unsafe { std::ptr::read(stub) })
    }
}

#[repr(C)]
struct IEntityStubSystemVft {
    base: red4ext_rs::types::IGameSystemVft,
    create_stub: VoidPtr,
    restore_stub: VoidPtr,
    cancel_stub: VoidPtr,
    delete_stub: VoidPtr,
    find_stub:
        unsafe extern "C" fn(this: &IEntityStubSystem, entity_id: EntityId) -> *const EntityStub,
    sub_1d0: VoidPtr,
    sub_1d8: VoidPtr,
    sub_1e0: VoidPtr,
    sub_1e8: VoidPtr,
    sub_1f0: VoidPtr,
    sub_1f8: VoidPtr,
    sub_200: VoidPtr,
    sub_208: VoidPtr,
    sub_210: VoidPtr,
    sub_218: VoidPtr,
}
```