### PR TITLE
Fix Dependabot/cargo/bindgen 0.73

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn main() {
         .clang_arg("-std=c++20")
         .clang_arg(format!("-I{}", red4ext_include_dir.display()))
         .header("deps/wrapper.hpp")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(Callbacks::default()))
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
         .derive_default(true)
         .enable_cxx_namespaces()
@@ -52,4 +52,34 @@ fn main() {
         "cargo:warning=Generated bindings: {}",
         out_path.join("bindings.rs").display()
     );
+}
+
+#[derive(Debug, Default)]
+struct Callbacks(bindgen::CargoCallbacks);
+
+impl bindgen::callbacks::ParseCallbacks for Callbacks {
+    fn add_derives(&self, info: &bindgen::callbacks::DeriveInfo<'_>) -> Vec<String> {
+        if [
+            "CClass",
+            "CBaseFunction",
+            "CGlobalFunction",
+            "CClassFunction",
+            "CClassStaticFunction",
+        ]
+        .contains(&info.name)
+        {
+            vec!["Debug".to_string()]
+        } else {
+            vec![]
+        }
+    }
+    fn header_file(&self, filename: &str) {
+        self.0.header_file(filename);
+    }
+    fn include_file(&self, filename: &str) {
+        self.0.include_file(filename);
+    }
+    fn read_env_var(&self, key: &str) {
+        self.0.read_env_var(key);
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -73,12 +73,15 @@ impl bindgen::callbacks::ParseCallbacks for Callbacks {
             vec![]
         }
     }
+
     fn header_file(&self, filename: &str) {
         self.0.header_file(filename);
     }
+
     fn include_file(&self, filename: &str) {
         self.0.include_file(filename);
     }
+
     fn read_env_var(&self, key: &str) {
         self.0.read_env_var(key);
     }

--- a/src/types/time/game.rs
+++ b/src/types/time/game.rs
@@ -81,7 +81,12 @@ impl GameTime {
 
 impl std::fmt::Display for GameTime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let [day, hour, min, sec] = unsafe { self.0.ToString().0 };
+        let [day, hour, min, sec] = [
+            unsafe { self.0.GetDay() },
+            unsafe { self.0.GetHour() },
+            unsafe { self.0.GetMinute() },
+            unsafe { self.0.GetSecond() },
+        ];
         write!(f, "{day}T{hour}:{min}:{sec}")
     }
 }

--- a/src/types/time/game.rs
+++ b/src/types/time/game.rs
@@ -81,13 +81,14 @@ impl GameTime {
 
 impl std::fmt::Display for GameTime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let [day, hour, min, sec] = [
-            unsafe { self.0.GetDay() },
-            unsafe { self.0.GetHour() },
-            unsafe { self.0.GetMinute() },
-            unsafe { self.0.GetSecond() },
-        ];
-        write!(f, "{day}T{hour}:{min}:{sec}")
+        write!(
+            f,
+            "{}T{}:{}:{}",
+            self.day(),
+            self.hour(),
+            self.minute(),
+            self.second()
+        )
     }
 }
 


### PR DESCRIPTION
Fix failed dependabot attempt at bumping `bindgen`.
Also it seems `RED4ext.SDK` has had some more fundamental changes, but this only affected `GameTime` so far.